### PR TITLE
Migrate from deprecated card-reader to smartcard package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
             "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "card-reader": "^1.0.5",
-                "iso7816": "^1.0.20",
+                "smartcard": "^3.4.0",
                 "tlv": "^1.1.1"
             },
             "devDependencies": {
@@ -1595,15 +1594,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/apdu": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/apdu/-/apdu-0.0.3.tgz",
-            "integrity": "sha1-NnSD62iY8wWkBQAqHlBhzNKTOFs= sha512-WQVThWhemt9BSEHrGK0fzsUJWizWlTMMm5U1j1wPcW4qb0iEuiegffJgJZCK+Nvch3uBcMTaDq5a7jsvP+ePxQ==",
-            "license": "MIT",
-            "dependencies": {
-                "hexify": "^1.0.1"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1646,15 +1636,6 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c= sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "license": "MIT",
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1703,17 +1684,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/card-reader": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/card-reader/-/card-reader-1.0.5.tgz",
-            "integrity": "sha512-lYJHdWLPclHHeNapUAyGD9QjMqayce8JbEPl2kRz2mNsZsevxjRlMohfI5SaSJkhqRsbk+70/ebPDnP6zLBN1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "core-js": "^3.8.3",
-                "hexify": "^1.0.4",
-                "pcsclite": "^1.0.0"
-            }
-        },
         "node_modules/chai": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1756,18 +1726,6 @@
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
-            }
-        },
-        "node_modules/core-js": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-            "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/cross-spawn": {
@@ -2169,12 +2127,6 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "license": "MIT"
-        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2253,12 +2205,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/hexify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/hexify/-/hexify-1.0.4.tgz",
-            "integrity": "sha512-MlomXO1y3bUmMCOmz5EXf2qIjmgCs+sW6/HsBxXpXu8lsqH3aXHt78MHwdfe/esdNU5ai2/5KIpEI6KEUKAQ0g==",
-            "license": "ISC"
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2332,17 +2278,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/iso7816": {
-            "version": "1.0.20",
-            "resolved": "https://registry.npmjs.org/iso7816/-/iso7816-1.0.20.tgz",
-            "integrity": "sha1-c7RF2wO1tFx6xSkHYpFie1dZ6+Y= sha512-w9kuOQQVoafBliQMG9+O4N+ldhoY8QtFPlXvoydRhc7I9Z3ehMTLsnlrA/v2XmlmsyU3aysPf2zYzrooEiTxew==",
-            "license": "MIT",
-            "dependencies": {
-                "apdu": "^0.0.3",
-                "card-reader": "^1.0.3",
-                "hexify": "^1.0.1"
-            }
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
@@ -2638,12 +2573,6 @@
                 "thenify-all": "^1.0.0"
             }
         },
-        "node_modules/nan": {
-            "version": "2.14.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-            "license": "MIT"
-        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2668,6 +2597,12 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "license": "MIT"
         },
         "node_modules/object-assign": {
@@ -2780,20 +2715,6 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pcsclite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/pcsclite/-/pcsclite-1.0.0.tgz",
-            "integrity": "sha512-hmn4qYxdqhI7ysutE9sPaHwOnMunNK3LxByv4HnuME95KOfCuAywyBjV0gSVkU8ZUxMV0Ug2Fs1nLdv2V9xThA==",
-            "hasInstallScript": true,
-            "license": "ISC",
-            "dependencies": {
-                "bindings": "^1.1.0",
-                "nan": "^2.14.0"
-            },
-            "engines": {
-                "node": ">=4.8.0"
-            }
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -3013,6 +2934,24 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/smartcard": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/smartcard/-/smartcard-3.4.0.tgz",
+            "integrity": "sha512-qAjPGV2R5xh7Fj2PtVJQ4jLNuZlN6D6Bsrwlc31N/N2S7KClzWX4SloUh0VSgNj8WEDqXNXBo2jyO9/HpnXyZA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "os": [
+                "darwin",
+                "linux",
+                "win32"
+            ],
+            "dependencies": {
+                "node-addon-api": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     },
     "homepage": "https://github.com/tomkp/emv",
     "dependencies": {
-        "card-reader": "^1.0.5",
-        "iso7816": "^1.0.20",
+        "smartcard": "^3.4.0",
         "tlv": "^1.1.1"
     },
     "devDependencies": {

--- a/src/emv-application.ts
+++ b/src/emv-application.ts
@@ -1,5 +1,4 @@
-import iso7816 from 'iso7816';
-import type { CardReader, CardResponse, Iso7816 } from './types.js';
+import type { CardResponse, SmartCard, Reader } from './types.js';
 
 /**
  * Payment System Environment (PSE) identifier
@@ -10,35 +9,102 @@ const PSE = Buffer.from([
 ]);
 
 /**
+ * Parse APDU response into CardResponse
+ */
+function parseResponse(response: Buffer): CardResponse {
+    const sw1 = response[response.length - 2] ?? 0;
+    const sw2 = response[response.length - 1] ?? 0;
+    const data = response.subarray(0, response.length - 2);
+
+    return {
+        buffer: data,
+        sw1,
+        sw2,
+        isOk: () => sw1 === 0x90 && sw2 === 0x00,
+    };
+}
+
+/**
+ * Build SELECT FILE APDU command
+ */
+function buildSelectApdu(data: Buffer): Buffer {
+    return Buffer.from([
+        0x00, // CLA
+        0xa4, // INS: SELECT
+        0x04, // P1: Select by DF name
+        0x00, // P2: First or only occurrence
+        data.length, // Lc
+        ...data,
+        0x00, // Le: Maximum response length
+    ]);
+}
+
+/**
+ * Build READ RECORD APDU command
+ */
+function buildReadRecordApdu(sfi: number, record: number): Buffer {
+    const p2 = (sfi << 3) | 0x04; // SFI in upper 5 bits, 0x04 = read record
+    return Buffer.from([
+        0x00, // CLA
+        0xb2, // INS: READ RECORD
+        record, // P1: Record number
+        p2, // P2: SFI and read mode
+        0x00, // Le: Maximum response length
+    ]);
+}
+
+/**
  * EMV Application for interacting with chip cards via PC/SC readers.
+ *
+ * @example
+ * ```typescript
+ * import { Devices } from 'smartcard';
+ * import { EmvApplication, format } from 'emv';
+ *
+ * const devices = new Devices();
+ *
+ * devices.on('card-inserted', async ({ reader, card }) => {
+ *     const emv = new EmvApplication(reader, card);
+ *     const response = await emv.selectPse();
+ *     console.log(format(response));
+ * });
+ *
+ * devices.start();
+ * ```
  */
 export class EmvApplication {
-    readonly #iso7816: Iso7816;
+    readonly #card: SmartCard;
+    readonly #reader: Reader;
 
-    constructor(devices: unknown, cardReader: CardReader) {
-        this.#iso7816 = iso7816(devices, cardReader) as Iso7816;
+    constructor(reader: Reader, card: SmartCard) {
+        this.#reader = reader;
+        this.#card = card;
     }
 
     /**
      * Select the Payment System Environment (PSE) directory.
      * This is typically the first command sent to a payment card.
      */
-    selectPse(): Promise<CardResponse> {
-        return this.#iso7816.selectFile(PSE);
+    async selectPse(): Promise<CardResponse> {
+        const apdu = buildSelectApdu(PSE);
+        const response = await this.#card.transmit(apdu);
+        return parseResponse(response);
     }
 
     /**
      * Select an EMV application by its AID.
      * @param aid - Application Identifier (5-16 bytes)
      */
-    selectApplication(aid: Buffer | readonly number[]): Promise<CardResponse> {
+    async selectApplication(aid: Buffer | readonly number[]): Promise<CardResponse> {
         const aidBuffer = Buffer.isBuffer(aid) ? aid : Buffer.from(aid);
 
         if (aidBuffer.length < 5 || aidBuffer.length > 16) {
             throw new RangeError('AID must be between 5 and 16 bytes');
         }
 
-        return this.#iso7816.selectFile(aidBuffer);
+        const apdu = buildSelectApdu(aidBuffer);
+        const response = await this.#card.transmit(apdu);
+        return parseResponse(response);
     }
 
     /**
@@ -46,7 +112,7 @@ export class EmvApplication {
      * @param sfi - Short File Identifier (1-30)
      * @param record - Record number (0-255)
      */
-    readRecord(sfi: number, record: number): Promise<CardResponse> {
+    async readRecord(sfi: number, record: number): Promise<CardResponse> {
         if (!Number.isInteger(sfi) || sfi < 1 || sfi > 30) {
             throw new RangeError('SFI must be an integer between 1 and 30');
         }
@@ -55,15 +121,31 @@ export class EmvApplication {
             throw new RangeError('Record number must be an integer between 0 and 255');
         }
 
-        return this.#iso7816.readRecord(sfi, record);
+        const apdu = buildReadRecordApdu(sfi, record);
+        const response = await this.#card.transmit(apdu);
+        return parseResponse(response);
+    }
+
+    /**
+     * Get the card's ATR (Answer To Reset)
+     */
+    getAtr(): string {
+        return this.#card.atr.toString('hex');
+    }
+
+    /**
+     * Get the reader name
+     */
+    getReaderName(): string {
+        return this.#reader.name;
     }
 }
 
 /**
  * Factory function to create an EmvApplication instance
  */
-export function createEmvApplication(devices: unknown, cardReader: CardReader): EmvApplication {
-    return new EmvApplication(devices, cardReader);
+export function createEmvApplication(reader: Reader, card: SmartCard): EmvApplication {
+    return new EmvApplication(reader, card);
 }
 
 export default createEmvApplication;

--- a/src/externals.d.ts
+++ b/src/externals.d.ts
@@ -8,19 +8,3 @@ declare module 'tlv' {
 
     export = { parse };
 }
-
-declare module 'iso7816' {
-    interface CardResponse {
-        buffer: Buffer;
-        isOk(): boolean;
-    }
-
-    interface Iso7816 {
-        selectFile(data: Buffer | number[]): Promise<CardResponse>;
-        readRecord(sfi: number, record: number): Promise<CardResponse>;
-    }
-
-    function iso7816(devices: unknown, cardReader: unknown): Iso7816;
-
-    export = iso7816;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,3 @@
 export { EmvApplication, createEmvApplication, default } from './emv-application.js';
 export { EMV_TAGS, format, findTag, getTagName } from './emv-tags.js';
-export type {
-    CardResponse,
-    TlvData,
-    EmvApplicationInfo,
-    CardReader,
-    Iso7816,
-    Iso7816Factory,
-} from './types.js';
+export type { CardResponse, TlvData, EmvApplicationInfo, SmartCard, Reader } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@ export interface CardResponse {
     buffer: Buffer;
     /** Check if the response indicates success (SW1=0x90, SW2=0x00) */
     isOk(): boolean;
+    /** Status word 1 */
+    sw1: number;
+    /** Status word 2 */
+    sw2: number;
 }
 
 /**
@@ -31,21 +35,19 @@ export interface EmvApplicationInfo {
 }
 
 /**
- * Card reader device interface
+ * Card interface from smartcard package
  */
-export interface CardReader {
+export interface SmartCard {
+    /** Answer to Reset */
+    atr: Buffer;
+    /** Transmit APDU command to card */
+    transmit(apdu: Buffer | number[]): Promise<Buffer>;
+}
+
+/**
+ * Reader interface from smartcard package
+ */
+export interface Reader {
+    /** Reader name */
     name: string;
 }
-
-/**
- * ISO7816 interface for smartcard communication
- */
-export interface Iso7816 {
-    selectFile(data: Buffer | number[]): Promise<CardResponse>;
-    readRecord(sfi: number, record: number): Promise<CardResponse>;
-}
-
-/**
- * Factory function type for creating ISO7816 instances
- */
-export type Iso7816Factory = (devices: unknown, cardReader: CardReader) => Iso7816;

--- a/tests/emv-application.test.ts
+++ b/tests/emv-application.test.ts
@@ -1,35 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CardReader } from '../src/types.js';
-
-// Mock iso7816 before importing EmvApplication
-vi.mock('iso7816', () => ({
-    default: vi.fn(() => ({
-        selectFile: vi.fn().mockResolvedValue({
-            buffer: Buffer.from([0x6f, 0x00]),
-            isOk: () => true,
-            sw1: 0x90,
-            sw2: 0x00,
-        }),
-        readRecord: vi.fn().mockResolvedValue({
-            buffer: Buffer.from([]),
-            isOk: () => false,
-            sw1: 0x6a,
-            sw2: 0x83,
-        }),
-    })),
-}));
-
+import type { SmartCard, Reader } from '../src/types.js';
 import { EmvApplication } from '../src/emv-application.js';
 
 describe('EmvApplication', () => {
     let emv: EmvApplication;
-    let mockDevices: unknown;
-    let mockReader: CardReader;
+    let mockReader: Reader;
+    let mockCard: SmartCard;
+    let transmitMock: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-        mockDevices = {};
+        // Response with SW1=90 SW2=00 (success)
+        transmitMock = vi.fn().mockResolvedValue(Buffer.from([0x6f, 0x00, 0x90, 0x00]));
         mockReader = { name: 'Test Reader' };
-        emv = new EmvApplication(mockDevices, mockReader);
+        mockCard = {
+            atr: Buffer.from([0x3b, 0x8f, 0x80, 0x01]),
+            transmit: transmitMock,
+        };
+        emv = new EmvApplication(mockReader, mockCard);
     });
 
     describe('constructor', () => {
@@ -38,24 +25,52 @@ describe('EmvApplication', () => {
         });
     });
 
+    describe('getAtr', () => {
+        it('should return ATR as hex string', () => {
+            expect(emv.getAtr()).toBe('3b8f8001');
+        });
+    });
+
+    describe('getReaderName', () => {
+        it('should return reader name', () => {
+            expect(emv.getReaderName()).toBe('Test Reader');
+        });
+    });
+
     describe('selectPse', () => {
-        it('should call selectFile with PSE identifier', async () => {
+        it('should transmit SELECT APDU for PSE', async () => {
             const response = await emv.selectPse();
             expect(response).toBeDefined();
             expect(response.isOk()).toBe(true);
+            expect(transmitMock).toHaveBeenCalledTimes(1);
+
+            // Verify APDU structure
+            const apdu = transmitMock.mock.calls[0]?.[0] as Buffer;
+            expect(apdu[0]).toBe(0x00); // CLA
+            expect(apdu[1]).toBe(0xa4); // INS: SELECT
+            expect(apdu[2]).toBe(0x04); // P1
+            expect(apdu[3]).toBe(0x00); // P2
+        });
+
+        it('should parse response correctly', async () => {
+            transmitMock.mockResolvedValue(Buffer.from([0x6f, 0x0a, 0x84, 0x07, 0x90, 0x00]));
+            const response = await emv.selectPse();
+            expect(response.sw1).toBe(0x90);
+            expect(response.sw2).toBe(0x00);
+            expect(response.buffer.toString('hex')).toBe('6f0a8407');
         });
     });
 
     describe('selectApplication', () => {
-        it('should throw RangeError for AID shorter than 5 bytes', () => {
-            expect(() => emv.selectApplication([0xa0, 0x00, 0x00, 0x00])).toThrow(
+        it('should throw RangeError for AID shorter than 5 bytes', async () => {
+            await expect(emv.selectApplication([0xa0, 0x00, 0x00, 0x00])).rejects.toThrow(
                 /AID must be between 5 and 16 bytes/
             );
         });
 
-        it('should throw RangeError for AID longer than 16 bytes', () => {
+        it('should throw RangeError for AID longer than 16 bytes', async () => {
             const longAid = new Array(17).fill(0xa0);
-            expect(() => emv.selectApplication(longAid)).toThrow(
+            await expect(emv.selectApplication(longAid)).rejects.toThrow(
                 /AID must be between 5 and 16 bytes/
             );
         });
@@ -79,48 +94,75 @@ describe('EmvApplication', () => {
             const aid = new Array(16).fill(0xa0);
             await expect(emv.selectApplication(aid)).resolves.toBeDefined();
         });
+
+        it('should include AID in APDU', async () => {
+            const aid = [0xa0, 0x00, 0x00, 0x00, 0x04];
+            await emv.selectApplication(aid);
+            const apdu = transmitMock.mock.calls[0]?.[0] as Buffer;
+            expect(apdu[4]).toBe(5); // Lc = length of AID
+            expect(apdu.subarray(5, 10).toString('hex')).toBe('a000000004');
+        });
     });
 
     describe('readRecord', () => {
-        it('should throw RangeError for SFI less than 1', () => {
-            expect(() => emv.readRecord(0, 1)).toThrow(
+        it('should throw RangeError for SFI less than 1', async () => {
+            await expect(emv.readRecord(0, 1)).rejects.toThrow(
                 /SFI must be an integer between 1 and 30/
             );
         });
 
-        it('should throw RangeError for SFI greater than 30', () => {
-            expect(() => emv.readRecord(31, 1)).toThrow(
+        it('should throw RangeError for SFI greater than 30', async () => {
+            await expect(emv.readRecord(31, 1)).rejects.toThrow(
                 /SFI must be an integer between 1 and 30/
             );
         });
 
-        it('should throw RangeError for negative record number', () => {
-            expect(() => emv.readRecord(1, -1)).toThrow(
+        it('should throw RangeError for negative record number', async () => {
+            await expect(emv.readRecord(1, -1)).rejects.toThrow(
                 /Record number must be an integer between 0 and 255/
             );
         });
 
-        it('should throw RangeError for record number greater than 255', () => {
-            expect(() => emv.readRecord(1, 256)).toThrow(
+        it('should throw RangeError for record number greater than 255', async () => {
+            await expect(emv.readRecord(1, 256)).rejects.toThrow(
                 /Record number must be an integer between 0 and 255/
             );
         });
 
-        it('should throw RangeError for non-integer SFI', () => {
-            expect(() => emv.readRecord(1.5, 1)).toThrow(
+        it('should throw RangeError for non-integer SFI', async () => {
+            await expect(emv.readRecord(1.5, 1)).rejects.toThrow(
                 /SFI must be an integer between 1 and 30/
             );
         });
 
-        it('should throw RangeError for non-integer record', () => {
-            expect(() => emv.readRecord(1, 1.5)).toThrow(
+        it('should throw RangeError for non-integer record', async () => {
+            await expect(emv.readRecord(1, 1.5)).rejects.toThrow(
                 /Record number must be an integer between 0 and 255/
             );
         });
 
         it('should accept valid SFI and record values', async () => {
-            await expect(emv.readRecord(1, 0)).resolves.toBeDefined();
+            await expect(emv.readRecord(1, 1)).resolves.toBeDefined();
             await expect(emv.readRecord(30, 255)).resolves.toBeDefined();
+        });
+
+        it('should encode SFI correctly in P2', async () => {
+            // Error response for non-existent record
+            transmitMock.mockResolvedValue(Buffer.from([0x6a, 0x83]));
+            await emv.readRecord(1, 1);
+            const apdu = transmitMock.mock.calls[0]?.[0] as Buffer;
+            expect(apdu[0]).toBe(0x00); // CLA
+            expect(apdu[1]).toBe(0xb2); // INS: READ RECORD
+            expect(apdu[2]).toBe(1); // P1: record number
+            expect(apdu[3]).toBe((1 << 3) | 0x04); // P2: SFI=1 in upper 5 bits, 0x04
+        });
+
+        it('should return non-OK response for error status words', async () => {
+            transmitMock.mockResolvedValue(Buffer.from([0x6a, 0x83])); // Record not found
+            const response = await emv.readRecord(1, 1);
+            expect(response.isOk()).toBe(false);
+            expect(response.sw1).toBe(0x6a);
+            expect(response.sw2).toBe(0x83);
         });
     });
 });


### PR DESCRIPTION
## Summary

Replace the deprecated `card-reader` package with the actively maintained `smartcard` package.

## Breaking Changes

**Constructor signature changed:**
```typescript
// Old (card-reader)
new EmvApplication(devices, reader)

// New (smartcard)
new EmvApplication(reader, card)
```

## Changes

- Replace `card-reader` dependency with `smartcard@^3.4.0`
- Remove `iso7816` dependency (APDU commands now built internally)
- Rewrite EmvApplication to use smartcard's `card.transmit()` API
- Add internal APDU building functions (`buildSelectApdu`, `buildReadRecordApdu`)
- Add `parseResponse()` for extracting status words from responses
- Add convenience methods: `getAtr()`, `getReaderName()`
- Update types to use `SmartCard` and `Reader` interfaces
- Update example to use smartcard event-driven API

## Benefits

- Works with Node.js 18, 20, and 22 (card-reader's pcsclite failed on Node 22)
- Actively maintained package with modern N-API bindings
- Built-in TypeScript definitions
- No native compilation issues in CI

## Test plan

- [x] All 33 tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Build succeeds

Closes #9