### PR TITLE
Fix inconsistent key quoting in EMV_TAGS

### DIFF
--- a/src/emv-tags.ts
+++ b/src/emv-tags.ts
@@ -109,8 +109,8 @@ export const EMV_TAGS = {
     '9F49': 'DDOL',
     '9F4A': 'STATIC_DATA_AUTHENTICATION_TAG_LIST',
     '9F4C': 'ICC_DYNAMIC_NUMBER',
-    A5: 'FCI_TEMPLATE',
-    BF0C: 'FCI_ISSUER_DD',
+    'A5': 'FCI_TEMPLATE',
+    'BF0C': 'FCI_ISSUER_DD',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- Quote `A5` and `BF0C` keys in EMV_TAGS to match the style of all other keys

All other keys in the EMV_TAGS object use quoted strings. These two were unquoted, which while valid JavaScript is inconsistent.

## Test plan
- [x] All tests pass
- [x] Build succeeds

Fixes #23