### PR TITLE
Fix externals.d.ts export syntax

### DIFF
--- a/src/externals.d.ts
+++ b/src/externals.d.ts
@@ -6,5 +6,6 @@ declare module 'tlv' {
 
     function parse(buffer: Buffer): TlvData;
 
-    export = { parse };
+    export { parse };
+    export default { parse };
 }


### PR DESCRIPTION
## Summary
- Fix invalid `export = { parse }` syntax in the tlv module declaration
- Replace with valid ESM export syntax

## Test plan
- [x] Build succeeds
- [x] All tests pass

Fixes #25