### PR TITLE
Upgrade ESLint config to strictTypeChecked

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,13 +4,17 @@ import globals from 'globals';
 
 export default tseslint.config(
     js.configs.recommended,
-    ...tseslint.configs.recommended,
+    ...tseslint.configs.strictTypeChecked,
     {
         languageOptions: {
             ecmaVersion: 2022,
             sourceType: 'module',
             globals: {
                 ...globals.node,
+            },
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         rules: {

--- a/src/emv-tags.ts
+++ b/src/emv-tags.ts
@@ -118,7 +118,10 @@ export const EMV_TAGS = {
  */
 export function getTagName(tag: number): string {
     const tagHex = tag.toString(16).toUpperCase();
-    return EMV_TAGS[tagHex as keyof typeof EMV_TAGS] ?? `UNKNOWN_${tagHex}`;
+    if (tagHex in EMV_TAGS) {
+        return EMV_TAGS[tagHex as keyof typeof EMV_TAGS];
+    }
+    return `UNKNOWN_${tagHex}`;
 }
 
 function formatTlvData(data: TlvData, indent = 0): string {


### PR DESCRIPTION
## Summary
- Upgrade from `tseslint.configs.recommended` to `strictTypeChecked` for stricter type-aware linting
- Add `parserOptions` with `projectService` for type-aware rules
- Fix `getTagName` function to use proper type-safe object lookup (the stricter config caught an unnecessary conditional)

## Test plan
- [x] `npm run lint` passes with new config
- [x] All 29 tests pass
- [x] Build succeeds

Fixes #31