### PR TITLE
Add smartcard as a runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@tomkp/ber-tlv": "^1.0.1",
-                "smartcard": "^3.4.0"
+                "smartcard": "^3.0.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -50,15 +50,8 @@
     },
     "homepage": "https://github.com/tomkp/emv",
     "dependencies": {
-        "@tomkp/ber-tlv": "^1.0.1"
-    },
-    "peerDependencies": {
+        "@tomkp/ber-tlv": "^1.0.1",
         "smartcard": "^3.0.0"
-    },
-    "peerDependenciesMeta": {
-        "smartcard": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",


### PR DESCRIPTION
## Summary
- Move smartcard from optional peer dependency to regular dependency
- Enables CLI tool functionality with direct PC/SC reader communication

## Test plan
- [x] npm install succeeds
- [x] All existing tests pass (63 tests)
- [x] Lint passes

Closes #51