### PR TITLE
Add basic CLI infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
     "name": "emv",
     "version": "2.0.0",
     "type": "module",
-    "description": "EMV / Chip and PIN library for PC/SC card readers",
+    "description": "EMV / Chip and PIN CLI and library for PC/SC card readers",
+    "bin": {
+        "emv": "./dist/cli.js"
+    },
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
@@ -38,6 +41,7 @@
         "iso-7816",
         "chip-and-pin",
         "emv",
+        "cli",
         "typescript"
     ],
     "license": "MIT",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { parseArgs, showHelp, showVersion } from './cli.js';
+
+describe('CLI', () => {
+    describe('parseArgs', () => {
+        it('should parse help flag', () => {
+            const result = parseArgs(['--help']);
+            assert.strictEqual(result.options.help, true);
+        });
+
+        it('should parse short help flag', () => {
+            const result = parseArgs(['-h']);
+            assert.strictEqual(result.options.help, true);
+        });
+
+        it('should parse version flag', () => {
+            const result = parseArgs(['--version']);
+            assert.strictEqual(result.options.version, true);
+        });
+
+        it('should parse short version flag', () => {
+            const result = parseArgs(['-v']);
+            assert.strictEqual(result.options.version, true);
+        });
+
+        it('should parse command as positional argument', () => {
+            const result = parseArgs(['readers']);
+            assert.deepStrictEqual(result.positionals, ['readers']);
+        });
+
+        it('should parse command with arguments', () => {
+            const result = parseArgs(['select-app', 'a0000000041010']);
+            assert.deepStrictEqual(result.positionals, ['select-app', 'a0000000041010']);
+        });
+
+        it('should parse format option', () => {
+            const result = parseArgs(['--format', 'json', 'readers']);
+            assert.strictEqual(result.options.format, 'json');
+        });
+
+        it('should parse short format option', () => {
+            const result = parseArgs(['-f', 'hex', 'info']);
+            assert.strictEqual(result.options.format, 'hex');
+        });
+
+        it('should parse verbose flag', () => {
+            const result = parseArgs(['--verbose', 'info']);
+            assert.strictEqual(result.options.verbose, true);
+        });
+
+        it('should parse reader option', () => {
+            const result = parseArgs(['--reader', 'SCM SCR3500', 'info']);
+            assert.strictEqual(result.options.reader, 'SCM SCR3500');
+        });
+
+        it('should parse short reader option', () => {
+            const result = parseArgs(['-r', 'ACR122U', 'info']);
+            assert.strictEqual(result.options.reader, 'ACR122U');
+        });
+    });
+
+    describe('showHelp', () => {
+        it('should return help text containing usage', () => {
+            const help = showHelp();
+            assert.ok(help.includes('Usage:'));
+        });
+
+        it('should list available commands', () => {
+            const help = showHelp();
+            assert.ok(help.includes('Commands:'));
+            assert.ok(help.includes('readers'));
+        });
+
+        it('should list options', () => {
+            const help = showHelp();
+            assert.ok(help.includes('Options:'));
+            assert.ok(help.includes('--help'));
+            assert.ok(help.includes('--version'));
+        });
+    });
+
+    describe('showVersion', () => {
+        it('should return version string', () => {
+            const version = showVersion();
+            assert.ok(/^\d+\.\d+\.\d+/.test(version));
+        });
+    });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { parseArgs as nodeParseArgs } from 'node:util';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface ParsedOptions {
+    help: boolean;
+    version: boolean;
+    format: string | undefined;
+    verbose: boolean;
+    reader: string | undefined;
+}
+
+interface ParsedArgs {
+    options: ParsedOptions;
+    positionals: string[];
+}
+
+/**
+ * Parse command line arguments
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+    const { values, positionals } = nodeParseArgs({
+        args,
+        options: {
+            help: { type: 'boolean', short: 'h' },
+            version: { type: 'boolean', short: 'v' },
+            format: { type: 'string', short: 'f' },
+            verbose: { type: 'boolean' },
+            reader: { type: 'string', short: 'r' },
+        },
+        allowPositionals: true,
+    });
+
+    return {
+        options: {
+            help: values.help ?? false,
+            version: values.version ?? false,
+            format: values.format,
+            verbose: values.verbose ?? false,
+            reader: values.reader,
+        },
+        positionals,
+    };
+}
+
+/**
+ * Show help text
+ */
+export function showHelp(): string {
+    return `EMV CLI - Interact with EMV chip cards
+
+Usage: emv [options] <command> [arguments]
+
+Commands:
+  readers              List available PC/SC readers
+  wait                 Wait for card insertion
+  info                 Show card information
+  select-pse           Select Payment System Environment
+  select-app <aid>     Select application by AID
+  list-apps            List applications on card
+  read-record <sfi> <record>  Read a record
+  get-data <tag>       Get data by EMV tag
+  dump                 Dump all readable card data
+  shell                Interactive mode
+
+Options:
+  -h, --help           Show this help message
+  -v, --version        Show version number
+  -f, --format <type>  Output format: text, json, hex (default: text)
+  --verbose            Show detailed output
+  -r, --reader <name>  Use specific reader by name
+
+Examples:
+  emv readers                    List all connected readers
+  emv wait                       Wait for a card to be inserted
+  emv info                       Show card ATR and basic info
+  emv select-pse                 Select PSE directory
+  emv select-app a0000000041010  Select Mastercard application
+  emv read-record 1 1            Read record 1 from SFI 1
+  emv get-data 9f17              Get PIN try counter
+  emv dump --format json         Dump card data as JSON
+  emv shell                      Start interactive mode
+`;
+}
+
+/**
+ * Get package version
+ */
+export function showVersion(): string {
+    try {
+        const packagePath = join(__dirname, '..', 'package.json');
+        const pkg = JSON.parse(readFileSync(packagePath, 'utf8')) as { version: string };
+        return pkg.version;
+    } catch {
+        return '0.0.0';
+    }
+}
+
+/**
+ * Main CLI entry point
+ */
+function main(): void {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.options.help) {
+        console.log(showHelp());
+        return;
+    }
+
+    if (args.options.version) {
+        console.log(showVersion());
+        return;
+    }
+
+    const command = args.positionals[0];
+
+    if (!command) {
+        console.log(showHelp());
+        return;
+    }
+
+    // Commands will be implemented in subsequent steps
+    console.error(`Command '${command}' not yet implemented`);
+    process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add CLI entry point (src/cli.ts) with argument parsing using Node.js built-in parseArgs
- Configure package.json with bin field for 'emv' command
- Add help text listing all planned commands
- Add version display from package.json
- Support --format, --verbose, --reader options
- Include comprehensive tests for CLI parsing (15 new tests)

## Test plan
- [x] All 78 tests pass (15 new CLI tests + 63 existing)
- [x] Lint passes
- [x] `node dist/cli.js --help` shows help
- [x] `node dist/cli.js --version` shows version

Closes #53