### PR TITLE
Implement card detection commands (readers, wait)

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { listReaders, waitForCard, type CommandContext } from './commands.js';
+
+function createMockContext(): { ctx: CommandContext; outputs: string[]; errors: string[] } {
+    const outputs: string[] = [];
+    const errors: string[] = [];
+    return {
+        ctx: {
+            output: (msg: string) => outputs.push(msg),
+            error: (msg: string) => errors.push(msg),
+            readerName: undefined,
+            format: undefined,
+            verbose: undefined,
+        },
+        outputs,
+        errors,
+    };
+}
+
+describe('Commands', () => {
+    describe('listReaders', () => {
+        it('should return empty array when no readers available', async () => {
+            const { ctx, outputs } = createMockContext();
+
+            const mockDevices = {
+                listReaders: () => [],
+                start: mock.fn(),
+                stop: mock.fn(),
+                on: mock.fn(),
+                once: mock.fn(),
+            };
+
+            const result = await listReaders(ctx, { devices: mockDevices });
+            assert.strictEqual(result, 0);
+            assert.strictEqual(outputs.length, 1);
+            assert.ok(outputs[0]?.includes('No readers'));
+        });
+
+        it('should list available readers', async () => {
+            const { ctx, outputs } = createMockContext();
+
+            const mockDevices = {
+                listReaders: () => [
+                    { name: 'Reader 1', state: 0, atr: null },
+                    { name: 'Reader 2', state: 0, atr: null },
+                ],
+                start: mock.fn(),
+                stop: mock.fn(),
+                on: mock.fn(),
+                once: mock.fn(),
+            };
+
+            const result = await listReaders(ctx, { devices: mockDevices });
+            assert.strictEqual(result, 0);
+            assert.ok(outputs.some((o) => o.includes('Reader 1')));
+            assert.ok(outputs.some((o) => o.includes('Reader 2')));
+        });
+
+        it('should indicate when a card is present', async () => {
+            const { ctx, outputs } = createMockContext();
+
+            const mockDevices = {
+                listReaders: () => [
+                    { name: 'Reader 1', state: 0x20, atr: Buffer.from([0x3b, 0x90]) }, // SCARD_STATE_PRESENT = 0x20
+                ],
+                start: mock.fn(),
+                stop: mock.fn(),
+                on: mock.fn(),
+                once: mock.fn(),
+            };
+
+            const result = await listReaders(ctx, { devices: mockDevices });
+            assert.strictEqual(result, 0);
+            assert.ok(outputs.some((o) => o.includes('card present')));
+        });
+    });
+
+    describe('waitForCard', () => {
+        it('should wait for card and return ATR', async () => {
+            const { ctx, outputs } = createMockContext();
+
+            const mockCard = {
+                atr: Buffer.from([0x3b, 0x90, 0x00]),
+                protocol: 1,
+                connected: true,
+                transmit: mock.fn(),
+            };
+
+            type EventHandler = (event: { reader: { name: string }; card: typeof mockCard }) => void;
+            let cardInsertedHandler: EventHandler | undefined;
+
+            const mockDevices = {
+                listReaders: () => [{ name: 'Test Reader', state: 0, atr: null }],
+                start: mock.fn(() => {
+                    // Simulate card insertion after start
+                    setTimeout(() => {
+                        if (cardInsertedHandler) {
+                            cardInsertedHandler({ reader: { name: 'Test Reader' }, card: mockCard });
+                        }
+                    }, 10);
+                }),
+                stop: mock.fn(),
+                on: mock.fn((event: string, handler: EventHandler) => {
+                    if (event === 'card-inserted') {
+                        cardInsertedHandler = handler;
+                    }
+                }),
+                once: mock.fn(),
+            };
+
+            const result = await waitForCard(ctx, { devices: mockDevices, timeout: 1000 });
+            assert.strictEqual(result, 0);
+            assert.ok(outputs.some((o) => o.includes('3b9000')));
+        });
+
+        it('should timeout when no card inserted', async () => {
+            const { ctx, errors } = createMockContext();
+
+            const mockDevices = {
+                listReaders: () => [{ name: 'Test Reader', state: 0, atr: null }],
+                start: mock.fn(),
+                stop: mock.fn(),
+                on: mock.fn(),
+                once: mock.fn(),
+            };
+
+            const result = await waitForCard(ctx, { devices: mockDevices, timeout: 50 });
+            assert.strictEqual(result, 1);
+            assert.ok(errors[0]?.includes('Timeout'));
+        });
+
+        it('should filter by reader name when specified', async () => {
+            const { ctx, outputs } = createMockContext();
+            ctx.readerName = 'Specific Reader';
+
+            const mockCard = {
+                atr: Buffer.from([0x3b, 0x90]),
+                protocol: 1,
+                connected: true,
+                transmit: mock.fn(),
+            };
+
+            type EventHandler = (event: { reader: { name: string }; card: typeof mockCard }) => void;
+            let cardInsertedHandler: EventHandler | undefined;
+
+            const mockDevices = {
+                listReaders: () => [
+                    { name: 'Other Reader', state: 0, atr: null },
+                    { name: 'Specific Reader', state: 0, atr: null },
+                ],
+                start: mock.fn(() => {
+                    setTimeout(() => {
+                        if (cardInsertedHandler) {
+                            // First emit for wrong reader (should be ignored)
+                            cardInsertedHandler({ reader: { name: 'Other Reader' }, card: mockCard });
+                            // Then emit for correct reader
+                            cardInsertedHandler({ reader: { name: 'Specific Reader' }, card: mockCard });
+                        }
+                    }, 10);
+                }),
+                stop: mock.fn(),
+                on: mock.fn((event: string, handler: EventHandler) => {
+                    if (event === 'card-inserted') {
+                        cardInsertedHandler = handler;
+                    }
+                }),
+                once: mock.fn(),
+            };
+
+            const result = await waitForCard(ctx, { devices: mockDevices, timeout: 1000 });
+            assert.strictEqual(result, 0);
+            assert.ok(outputs.some((o) => o.includes('Specific Reader')));
+        });
+    });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,153 @@
+/**
+ * CLI command implementations
+ */
+
+const SCARD_STATE_PRESENT = 0x20;
+
+/**
+ * Context for command execution
+ */
+export interface CommandContext {
+    output: (message: string) => void;
+    error: (message: string) => void;
+    readerName: string | undefined;
+    format: string | undefined;
+    verbose: boolean | undefined;
+}
+
+/**
+ * Minimal Reader interface for commands
+ */
+interface ReaderInfo {
+    name: string;
+    state: number;
+    atr: Buffer | null;
+}
+
+/**
+ * Minimal Card interface for commands
+ */
+interface CardInfo {
+    atr: Buffer | null;
+    protocol: number;
+    connected: boolean;
+}
+
+/**
+ * Card inserted event
+ */
+interface CardInsertedEvent {
+    reader: ReaderInfo;
+    card: CardInfo;
+}
+
+/**
+ * Minimal Devices interface for dependency injection
+ */
+interface DevicesLike {
+    listReaders(): ReaderInfo[];
+    start(): void;
+    stop(): void;
+    on(event: string, handler: (event: unknown) => void): void;
+    once(event: string, handler: (event: unknown) => void): void;
+}
+
+/**
+ * Options for commands (for dependency injection in tests)
+ */
+export interface CommandOptions {
+    devices?: DevicesLike;
+    timeout?: number;
+}
+
+/**
+ * List available PC/SC readers
+ */
+export async function listReaders(
+    ctx: CommandContext,
+    options: CommandOptions = {}
+): Promise<number> {
+    const devices = options.devices ?? (await createDevices());
+
+    try {
+        devices.start();
+        // Small delay to allow readers to be detected
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        const readers = devices.listReaders();
+
+        if (readers.length === 0) {
+            ctx.output('No readers found');
+            return 0;
+        }
+
+        ctx.output(`Found ${String(readers.length)} reader(s):\n`);
+
+        for (const reader of readers) {
+            const hasCard = (reader.state & SCARD_STATE_PRESENT) !== 0;
+            const cardStatus = hasCard ? ' (card present)' : '';
+            ctx.output(`  ${reader.name}${cardStatus}`);
+
+            if (hasCard && reader.atr && ctx.verbose) {
+                ctx.output(`    ATR: ${reader.atr.toString('hex')}`);
+            }
+        }
+
+        return 0;
+    } finally {
+        devices.stop();
+    }
+}
+
+/**
+ * Wait for a card to be inserted
+ */
+export async function waitForCard(
+    ctx: CommandContext,
+    options: CommandOptions = {}
+): Promise<number> {
+    const devices = options.devices ?? (await createDevices());
+    const timeout = options.timeout ?? 30000;
+
+    return new Promise((resolve) => {
+        const timeoutId = setTimeout(() => {
+            devices.stop();
+            ctx.error('Timeout waiting for card');
+            resolve(1);
+        }, timeout);
+
+        const handleCardInserted = (event: CardInsertedEvent) => {
+            // Filter by reader name if specified
+            if (ctx.readerName && event.reader.name !== ctx.readerName) {
+                return; // Ignore cards in other readers
+            }
+
+            clearTimeout(timeoutId);
+            devices.stop();
+
+            ctx.output(`Card inserted in: ${event.reader.name}`);
+            if (event.card.atr) {
+                ctx.output(`ATR: ${event.card.atr.toString('hex')}`);
+            }
+
+            resolve(0);
+        };
+
+        devices.on('card-inserted', handleCardInserted as (event: unknown) => void);
+
+        ctx.output('Waiting for card...');
+        if (ctx.readerName) {
+            ctx.output(`Using reader: ${ctx.readerName}`);
+        }
+
+        devices.start();
+    });
+}
+
+/**
+ * Create a Devices instance (lazy import to avoid loading native module in tests)
+ */
+async function createDevices(): Promise<DevicesLike> {
+    const { Devices } = await import('smartcard');
+    return new Devices() as DevicesLike;
+}


### PR DESCRIPTION
## Summary
- Add commands module with card detection functionality
- `emv readers` - List available PC/SC readers with card presence status
- `emv wait` - Wait for card insertion with timeout support
- Support for --reader flag to filter by reader name
- Support for --verbose flag to show ATR details

## Test plan
- [x] All 84 tests pass (6 new command tests + 78 existing)
- [x] Lint passes
- [x] Commands use dependency injection for testability

Closes #55