### PR TITLE
Implement PSE/AID selection commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -53,10 +53,30 @@ interface DevicesLike {
 }
 
 /**
+ * CardResponse interface for EMV commands
+ */
+interface CardResponse {
+    buffer: Buffer;
+    sw1: number;
+    sw2: number;
+    isOk(): boolean;
+}
+
+/**
+ * Minimal EmvApplication interface for dependency injection
+ */
+interface EmvLike {
+    selectPse?(): Promise<CardResponse>;
+    selectApplication?(aid: Buffer | readonly number[]): Promise<CardResponse>;
+    readRecord?(sfi: number, record: number): Promise<CardResponse>;
+}
+
+/**
  * Options for commands (for dependency injection in tests)
  */
 export interface CommandOptions {
     devices?: DevicesLike;
+    emv?: EmvLike;
     timeout?: number;
 }
 
@@ -150,4 +170,217 @@ export async function waitForCard(
 async function createDevices(): Promise<DevicesLike> {
     const { Devices } = await import('smartcard');
     return new Devices() as DevicesLike;
+}
+
+/**
+ * Format status word for display
+ */
+function formatSw(sw1: number, sw2: number): string {
+    return `SW: ${sw1.toString(16).padStart(2, '0').toUpperCase()}${sw2.toString(16).padStart(2, '0').toUpperCase()}`;
+}
+
+/**
+ * Select Payment System Environment
+ */
+export async function selectPse(
+    ctx: CommandContext,
+    options: CommandOptions = {}
+): Promise<number> {
+    const emv = options.emv;
+    if (!emv?.selectPse) {
+        ctx.error('EMV application not available');
+        return 1;
+    }
+
+    const response = await emv.selectPse();
+
+    if (response.isOk()) {
+        ctx.output('PSE selected successfully');
+        if (ctx.verbose) {
+            ctx.output(`Response: ${response.buffer.toString('hex')}`);
+        }
+        return 0;
+    } else {
+        ctx.error(`PSE selection failed - ${formatSw(response.sw1, response.sw2)}`);
+        return 1;
+    }
+}
+
+/**
+ * Parse hex string to buffer
+ */
+function parseHexAid(aid: string): Buffer | null {
+    // Remove any spaces or dashes
+    const cleaned = aid.replace(/[\s-]/g, '');
+
+    // Check valid hex string
+    if (!/^[0-9a-fA-F]+$/.test(cleaned)) {
+        return null;
+    }
+
+    // Must be even length (2 chars per byte)
+    if (cleaned.length % 2 !== 0) {
+        return null;
+    }
+
+    // AID must be 5-16 bytes
+    const length = cleaned.length / 2;
+    if (length < 5 || length > 16) {
+        return null;
+    }
+
+    return Buffer.from(cleaned, 'hex');
+}
+
+/**
+ * Select application by AID
+ */
+export async function selectApp(
+    ctx: CommandContext,
+    aidHex: string,
+    options: CommandOptions = {}
+): Promise<number> {
+    const aidBuffer = parseHexAid(aidHex);
+    if (!aidBuffer) {
+        ctx.error('Invalid AID format. AID must be 5-16 bytes in hex (e.g., a0000000041010)');
+        return 1;
+    }
+
+    const emv = options.emv;
+    if (!emv?.selectApplication) {
+        ctx.error('EMV application not available');
+        return 1;
+    }
+
+    const response = await emv.selectApplication(aidBuffer);
+
+    if (response.isOk()) {
+        ctx.output(`Application selected: ${aidHex}`);
+        if (ctx.verbose) {
+            ctx.output(`Response: ${response.buffer.toString('hex')}`);
+        }
+        return 0;
+    } else {
+        ctx.error(`Application selection failed - ${formatSw(response.sw1, response.sw2)}`);
+        return 1;
+    }
+}
+
+/**
+ * Find a tag in TLV data
+ */
+function findTag(data: Buffer, tag: number): Buffer | undefined {
+    let offset = 0;
+    while (offset < data.length) {
+        // Read tag
+        let currentTag = data[offset];
+        if (currentTag === undefined) break;
+        offset++;
+
+        // Handle two-byte tags
+        if ((currentTag & 0x1f) === 0x1f) {
+            const byte2 = data[offset];
+            if (byte2 === undefined) break;
+            currentTag = (currentTag << 8) | byte2;
+            offset++;
+        }
+
+        // Read length
+        let length = data[offset];
+        if (length === undefined) break;
+        offset++;
+
+        if (length === 0x81) {
+            length = data[offset];
+            if (length === undefined) break;
+            offset++;
+        } else if (length === 0x82) {
+            const b1 = data[offset];
+            const b2 = data[offset + 1];
+            if (b1 === undefined || b2 === undefined) break;
+            length = (b1 << 8) | b2;
+            offset += 2;
+        }
+
+        // Check if this is our tag
+        if (currentTag === tag) {
+            return data.subarray(offset, offset + length);
+        }
+
+        // If this is a constructed tag, search inside
+        if ((currentTag & 0x20) !== 0) {
+            const nested = findTag(data.subarray(offset, offset + length), tag);
+            if (nested) return nested;
+        }
+
+        offset += length;
+    }
+
+    return undefined;
+}
+
+/**
+ * List applications on card from PSE
+ */
+export async function listApps(
+    ctx: CommandContext,
+    options: CommandOptions = {}
+): Promise<number> {
+    const emv = options.emv;
+    if (!emv?.selectPse || !emv.readRecord) {
+        ctx.error('EMV application not available');
+        return 1;
+    }
+
+    // First select PSE
+    const pseResponse = await emv.selectPse();
+    if (!pseResponse.isOk()) {
+        ctx.error(`PSE selection failed - ${formatSw(pseResponse.sw1, pseResponse.sw2)}`);
+        return 1;
+    }
+
+    // Find SFI from PSE response (tag 88)
+    const sfiData = findTag(pseResponse.buffer, 0x88);
+    const sfi = sfiData?.[0] ?? 1;
+
+    // Read records to find applications
+    interface AppInfo {
+        aid: string;
+        label: string | undefined;
+        priority: number | undefined;
+    }
+    const apps: AppInfo[] = [];
+
+    for (let record = 1; record <= 10; record++) {
+        const response = await emv.readRecord(sfi, record);
+        if (!response.isOk()) break;
+
+        // Look for AID (tag 4F) in record
+        const aid = findTag(response.buffer, 0x4f);
+        if (aid) {
+            const label = findTag(response.buffer, 0x50);
+            const priority = findTag(response.buffer, 0x87);
+
+            apps.push({
+                aid: aid.toString('hex'),
+                label: label?.toString('ascii'),
+                priority: priority?.[0],
+            });
+        }
+    }
+
+    if (apps.length === 0) {
+        ctx.output('No applications found on card');
+        return 0;
+    }
+
+    ctx.output(`Found ${String(apps.length)} application(s):\n`);
+
+    for (const app of apps) {
+        const labelStr = app.label ? ` - ${app.label}` : '';
+        const priorityStr = app.priority !== undefined ? ` (priority: ${String(app.priority)})` : '';
+        ctx.output(`  ${app.aid}${labelStr}${priorityStr}`);
+    }
+
+    return 0;
 }


### PR DESCRIPTION
## Summary
- Add `emv select-pse` - Select Payment System Environment
- Add `emv select-app <aid>` - Select application by AID
- Add `emv list-apps` - List applications on card from PSE records
- TLV parsing for extracting AIDs, labels, and priorities
- Hex AID validation (5-16 bytes)
- Status word formatting for error messages

## Test plan
- [x] All 91 tests pass (7 new tests + 84 existing)
- [x] Lint passes

Closes #57