### PR TITLE
Implement info/diagnostic commands (info, dump)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ import {
     listApps,
     readRecord,
     getData,
+    cardInfo,
+    dumpCard,
     type CommandContext,
 } from './commands.js';
 
@@ -176,6 +178,10 @@ async function runCommand(
             }
             return getData(ctx, tagArg);
         }
+        case 'info':
+            return cardInfo(ctx);
+        case 'dump':
+            return dumpCard(ctx);
         default:
             ctx.error(`Command '${command}' not yet implemented`);
             return 1;


### PR DESCRIPTION
## Summary
- Add `emv info` - Show card information (ATR, reader, applications)
- Add `emv dump` - Dump all readable card data (PSE response, records)

## Test plan
- [x] All 101 tests pass (2 new tests + 99 existing)
- [x] Lint passes

Closes #61