### PR TITLE
Remove duplicate findTag, add findTagInBuffer export

### DIFF
--- a/src/emv-tags.ts
+++ b/src/emv-tags.ts
@@ -189,13 +189,13 @@ export function format(response: CardResponse): string {
 }
 
 /**
- * Find a specific tag in a card response
- * @param response - The card response to search
+ * Find a specific tag in a Buffer containing TLV data
+ * @param buffer - The buffer to search
  * @param tag - The tag number to find (e.g., 0x4F for APP_IDENTIFIER)
  * @returns The tag value as a Buffer, or undefined if not found
  */
-export function findTag(response: CardResponse, tag: number): Buffer | undefined {
-    const parsed = parse(response.buffer);
+export function findTagInBuffer(buffer: Buffer, tag: number): Buffer | undefined {
+    const parsed = parse(buffer);
     for (const tlv of parsed) {
         const result = findInTlv(tlv, tag);
         if (result !== undefined) {
@@ -203,4 +203,14 @@ export function findTag(response: CardResponse, tag: number): Buffer | undefined
         }
     }
     return undefined;
+}
+
+/**
+ * Find a specific tag in a card response
+ * @param response - The card response to search
+ * @param tag - The tag number to find (e.g., 0x4F for APP_IDENTIFIER)
+ * @returns The tag value as a Buffer, or undefined if not found
+ */
+export function findTag(response: CardResponse, tag: number): Buffer | undefined {
+    return findTagInBuffer(response.buffer, tag);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { EmvApplication, createEmvApplication, default } from './emv-application.js';
-export { EMV_TAGS, format, findTag, getTagName } from './emv-tags.js';
+export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName } from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';


### PR DESCRIPTION
## Summary
- Add `findTagInBuffer()` to emv-tags.ts for Buffer-based tag lookup
- Export `findTagInBuffer` from index.ts as part of public API  
- Refactor `findTag()` to use `findTagInBuffer` internally
- Remove duplicate 48-line `findTag` implementation from commands.ts
- Import `findTagInBuffer` in commands.ts to replace local implementation
- Add tests for `findTagInBuffer` function

This consolidates TLV tag searching to a single implementation using the @tomkp/ber-tlv library, removing code duplication and potential behavioral inconsistencies.

## Test plan
- [x] All existing tests pass
- [x] New `findTagInBuffer` tests added (3 tests)
- [x] 113 tests pass (up from 110)
- [x] Lint passes

Closes #67