### PR TITLE
Update installation instructions - smartcard is now bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EMV / Chip and PIN library for PC/SC card readers.
 ## Installation
 
 ```bash
-npm install emv smartcard
+npm install emv
 ```
 
 **Requirements:**


### PR DESCRIPTION
## Summary
Remove 'smartcard' from npm install command since it is now a direct dependency rather than a peer dependency.

Before: `npm install emv smartcard`
After: `npm install emv`

## Test plan
- [x] Documentation only change
- [x] Tests pass

Closes #69