### PR TITLE
Import CardResponse from types.ts instead of redefining

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,6 +3,7 @@
  */
 
 import { findTagInBuffer } from './emv-tags.js';
+import type { CardResponse } from './types.js';
 
 const SCARD_STATE_PRESENT = 0x20;
 
@@ -52,16 +53,6 @@ interface DevicesLike {
     stop(): void;
     on(event: string, handler: (event: unknown) => void): void;
     once(event: string, handler: (event: unknown) => void): void;
-}
-
-/**
- * CardResponse interface for EMV commands
- */
-interface CardResponse {
-    buffer: Buffer;
-    sw1: number;
-    sw2: number;
-    isOk(): boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
Remove local CardResponse interface definition in commands.ts and import from shared types module to avoid duplication.

## Test plan
- [x] All 113 tests pass
- [x] Lint passes

Closes #71