### PR TITLE
Remove hex format option from help text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,7 @@ Commands:
 Options:
   -h, --help           Show this help message
   -v, --version        Show version number
-  -f, --format <type>  Output format: text, json, hex (default: text)
+  -f, --format <type>  Output format: text, json (default: text)
   --verbose            Show detailed output
   -r, --reader <name>  Use specific reader by name
 


### PR DESCRIPTION
## Summary
Remove `hex` from the format options in help text since it was never implemented. Only `text` and `json` formats are supported.

## Test plan
- [x] All 120 tests pass
- [x] Help text is accurate

Closes #77