### PR TITLE
Add interactive CLI with React/Ink UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,24 @@
             "license": "MIT",
             "dependencies": {
                 "@tomkp/ber-tlv": "^1.0.1",
+                "boxen": "^5.1.2",
+                "chalk": "^4.1.2",
+                "figures": "^3.2.0",
+                "ink": "^6.6.0",
+                "ink-gradient": "^3.0.0",
+                "ink-select-input": "^6.2.0",
+                "ink-spinner": "^5.0.0",
+                "ink-text-input": "^6.0.0",
+                "react": "^19.2.3",
                 "smartcard": "^3.0.0"
+            },
+            "bin": {
+                "emv": "dist/cli.js"
             },
             "devDependencies": {
                 "@eslint/js": "^9.17.0",
                 "@types/node": "^25.0.3",
+                "@types/react": "^19.2.7",
                 "eslint": "^9.17.0",
                 "globals": "^16.5.0",
                 "prettier": "^3.4.2",
@@ -23,6 +36,31 @@
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@alcalzone/ansi-tokenize": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.2.tgz",
+            "integrity": "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -250,6 +288,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/gradient-string": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@types/gradient-string/-/gradient-string-1.1.6.tgz",
+            "integrity": "sha512-LkaYxluY4G5wR1M4AKQUal2q61Di1yVVCw42ImFTuaIoQVgmV0WP1xUaLB8zwb47mp82vWTpePI9JmrjEnJ7nQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/tinycolor2": "*"
+            }
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -266,6 +313,22 @@
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
+        },
+        "node_modules/@types/react": {
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/tinycolor2": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+            "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.50.1",
@@ -563,11 +626,46 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -586,12 +684,46 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/auto-bind": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+            "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/boxen": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+            "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.0",
+                "camelcase": "^6.2.0",
+                "chalk": "^4.1.0",
+                "cli-boxes": "^2.2.1",
+                "string-width": "^4.2.2",
+                "type-fest": "^0.20.2",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -614,11 +746,22 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -631,11 +774,93 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/cli-boxes": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+            "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+            "license": "MIT",
+            "dependencies": {
+                "slice-ansi": "^7.1.0",
+                "string-width": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate/node_modules/string-width": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+            "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/code-excerpt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+            "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+            "license": "MIT",
+            "dependencies": {
+                "convert-to-spaces": "^2.0.1"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -648,7 +873,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/concat-map": {
@@ -657,6 +881,15 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/convert-to-spaces": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+            "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -672,6 +905,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -697,6 +937,34 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.43.0.tgz",
+            "integrity": "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -904,6 +1172,30 @@
                 }
             }
         },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/figures/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -955,6 +1247,18 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -981,11 +1285,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/gradient-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-2.0.2.tgz",
+            "integrity": "sha512-rEDCuqUQ4tbD78TpzsMtt5OIf0cBCSDWSJtUDaF6JsAh+k0v9r++NzxNEG87oDZx9ZwGhD8DaezR2L/yrw0Jdw==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2",
+                "tinygradient": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -1028,6 +1344,311 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/indent-string": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/ink/-/ink-6.6.0.tgz",
+            "integrity": "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@alcalzone/ansi-tokenize": "^0.2.1",
+                "ansi-escapes": "^7.2.0",
+                "ansi-styles": "^6.2.1",
+                "auto-bind": "^5.0.1",
+                "chalk": "^5.6.0",
+                "cli-boxes": "^3.0.0",
+                "cli-cursor": "^4.0.0",
+                "cli-truncate": "^5.1.1",
+                "code-excerpt": "^4.0.0",
+                "es-toolkit": "^1.39.10",
+                "indent-string": "^5.0.0",
+                "is-in-ci": "^2.0.0",
+                "patch-console": "^2.0.0",
+                "react-reconciler": "^0.33.0",
+                "signal-exit": "^3.0.7",
+                "slice-ansi": "^7.1.0",
+                "stack-utils": "^2.0.6",
+                "string-width": "^8.1.0",
+                "type-fest": "^4.27.0",
+                "widest-line": "^5.0.0",
+                "wrap-ansi": "^9.0.0",
+                "ws": "^8.18.0",
+                "yoga-layout": "~3.2.1"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "@types/react": ">=19.0.0",
+                "react": ">=19.0.0",
+                "react-devtools-core": "^6.1.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react-devtools-core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ink-gradient": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ink-gradient/-/ink-gradient-3.0.0.tgz",
+            "integrity": "sha512-OVyPBovBxE1tFcBhSamb+P1puqDP6pG3xFe2W9NiLgwUZd9RbcjBeR7twLbliUT9navrUstEf1ZcPKKvx71BsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/gradient-string": "^1.1.2",
+                "gradient-string": "^2.0.2",
+                "prop-types": "^15.8.1",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            },
+            "peerDependencies": {
+                "ink": ">=4"
+            }
+        },
+        "node_modules/ink-select-input": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
+            "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
+            "license": "MIT",
+            "dependencies": {
+                "figures": "^6.1.0",
+                "to-rotated": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "ink": ">=5.0.0",
+                "react": ">=18.0.0"
+            }
+        },
+        "node_modules/ink-select-input/node_modules/figures": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-unicode-supported": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink-spinner": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+            "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+            "license": "MIT",
+            "dependencies": {
+                "cli-spinners": "^2.7.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "peerDependencies": {
+                "ink": ">=4.0.0",
+                "react": ">=18.0.0"
+            }
+        },
+        "node_modules/ink-text-input": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+            "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.3.0",
+                "type-fest": "^4.18.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "ink": ">=5",
+                "react": ">=18"
+            }
+        },
+        "node_modules/ink-text-input/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ink-text-input/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ink/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ink/node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
+        },
+        "node_modules/ink/node_modules/string-width": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+            "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/widest-line": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/widest-line/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ink/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/ink/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1036,6 +1657,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-glob": {
@@ -1051,12 +1687,45 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-in-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+            "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+            "license": "MIT",
+            "bin": {
+                "is-in-ci": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -1139,6 +1808,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1171,6 +1861,30 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "license": "MIT"
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -1235,6 +1949,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/patch-console": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+            "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1294,6 +2017,17 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1302,6 +2036,36 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/react": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+            "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-reconciler": {
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+            "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.0"
             }
         },
         "node_modules/resolve-from": {
@@ -1313,6 +2077,28 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/restore-cursor": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.3",
@@ -1350,10 +2136,44 @@
                 "node": ">=8"
             }
         },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/slice-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slice-ansi/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/smartcard": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/smartcard/-/smartcard-3.4.0.tgz",
-            "integrity": "sha512-qAjPGV2R5xh7Fj2PtVJQ4jLNuZlN6D6Bsrwlc31N/N2S7KClzWX4SloUh0VSgNj8WEDqXNXBo2jyO9/HpnXyZA==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/smartcard/-/smartcard-3.5.0.tgz",
+            "integrity": "sha512-0GO1rPosz50WfsRbs8UZl/FrcLXtOndeyuoOQwHopKogx9ad9KEKaVMCXCIG+H0qZLIRLDR0RYE10La/6xpgIw==",
             "hasInstallScript": true,
             "license": "MIT",
             "os": [
@@ -1366,6 +2186,86 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/stack-utils": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/stack-utils/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/strip-json-comments": {
@@ -1385,7 +2285,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -1393,6 +2292,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/tinycolor2": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+            "license": "MIT"
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
@@ -1409,6 +2314,28 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinygradient": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+            "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/tinycolor2": "^1.4.0",
+                "tinycolor2": "^1.0.0"
+            }
+        },
+        "node_modules/to-rotated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
+            "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ts-api-utils": {
@@ -1435,6 +2362,18 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typescript": {
@@ -1508,6 +2447,18 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/widest-line": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+            "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -1516,6 +2467,65 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/yocto-queue": {
@@ -1530,6 +2540,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/yoga-layout": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+            "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,11 +55,21 @@
     "homepage": "https://github.com/tomkp/emv",
     "dependencies": {
         "@tomkp/ber-tlv": "^1.0.1",
+        "boxen": "^5.1.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0",
+        "ink": "^6.6.0",
+        "ink-gradient": "^3.0.0",
+        "ink-select-input": "^6.2.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
+        "react": "^19.2.3",
         "smartcard": "^3.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@types/node": "^25.0.3",
+        "@types/react": "^19.2.7",
         "eslint": "^9.17.0",
         "globals": "^16.5.0",
         "prettier": "^3.4.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,9 +69,10 @@ export function parseArgs(args: string[]): ParsedArgs {
 export function showHelp(): string {
     return `EMV CLI - Interact with EMV chip cards
 
-Usage: emv [options] <command> [arguments]
+Usage: emv [options] [command] [arguments]
 
 Commands:
+  (no command)         Start interactive mode with beautiful UI
   readers              List available PC/SC readers
   wait                 Wait for card insertion
   info                 Show card information
@@ -82,7 +83,7 @@ Commands:
   get-data <tag>       Get data by EMV tag
   verify-pin <pin>     Verify cardholder PIN
   dump                 Dump all readable card data
-  shell                Interactive mode
+  shell                Text-based interactive mode
 
 Options:
   -h, --help           Show this help message
@@ -92,6 +93,7 @@ Options:
   -r, --reader <name>  Use specific reader by name
 
 Examples:
+  emv                            Start interactive UI mode
   emv readers                    List all connected readers
   emv wait                       Wait for a card to be inserted
   emv info                       Show card ATR and basic info
@@ -100,7 +102,7 @@ Examples:
   emv read-record 1 1            Read record 1 from SFI 1
   emv get-data 9f17              Get PIN try counter
   emv dump --format json         Dump card data as JSON
-  emv shell                      Start interactive mode
+  emv shell                      Start text-based interactive mode
 `;
 }
 
@@ -264,7 +266,9 @@ async function main(): Promise<void> {
     const command = args.positionals[0];
 
     if (!command) {
-        console.log(showHelp());
+        // Default to interactive mode when no command given
+        const { runInteractive } = await import('./interactive.js');
+        runInteractive();
         return;
     }
 

--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('Interactive CLI', () => {
+    describe('module exports', () => {
+        it('should export runInteractive function', async () => {
+            const module = await import('./interactive.js');
+            assert.strictEqual(typeof module.runInteractive, 'function');
+        });
+    });
+});

--- a/src/interactive.tsx
+++ b/src/interactive.tsx
@@ -1,0 +1,1073 @@
+#!/usr/bin/env node
+/**
+ * Interactive EMV CLI with a beautiful, modern UX
+ * Inspired by Claude Code and OpenCode
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { render, Box, Text, useApp, useInput, useStdin } from 'ink';
+import Spinner from 'ink-spinner';
+import SelectInput from 'ink-select-input';
+import TextInput from 'ink-text-input';
+import Gradient from 'ink-gradient';
+import { EmvApplication } from './emv-application.js';
+import { format as formatTlv, findTagInBuffer } from './emv-tags.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ReaderInfo {
+    name: string;
+    state: number;
+    atr: Buffer | null;
+}
+
+interface CardInfo {
+    atr: Buffer | null;
+    protocol: number;
+    connected: boolean;
+}
+
+interface DevicesLike {
+    listReaders(): ReaderInfo[];
+    start(): void;
+    stop(): void;
+    on(event: string, handler: (event: unknown) => void): void;
+    once(event: string, handler: (event: unknown) => void): void;
+    off(event: string, handler: (event: unknown) => void): void;
+    getCard(readerName: string): CardInfo | null;
+}
+
+interface CardInsertedEvent {
+    reader: ReaderInfo;
+    card: CardInfo;
+}
+
+interface AppInfo {
+    aid: string;
+    label: string | undefined;
+    priority: number | undefined;
+}
+
+type Screen =
+    | 'welcome'
+    | 'readers'
+    | 'waiting'
+    | 'apps'
+    | 'selected'
+    | 'pin'
+    | 'pin-result'
+    | 'explore'
+    | 'error';
+
+// ============================================================================
+// UI Components
+// ============================================================================
+
+const SCARD_STATE_PRESENT = 0x20;
+
+function Header(): React.JSX.Element {
+    return (
+        <Box flexDirection="column" marginBottom={1}>
+            <Gradient name="rainbow">
+                <Text bold>{'╔' + '═'.repeat(63) + '╗'}</Text>
+            </Gradient>
+            <Text color="cyan" bold>║{' '.repeat(63)}║</Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>███████╗███╗   ███╗██╗   ██╗</Text>
+                </Gradient>
+                <Text color="cyan">{' '.repeat(33)}║</Text>
+            </Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>██╔════╝████╗ ████║██║   ██║</Text>
+                </Gradient>
+                <Text color="yellow">   Chip &amp; PIN Explorer</Text>
+                <Text color="cyan">{' '.repeat(11)}║</Text>
+            </Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>█████╗  ██╔████╔██║██║   ██║</Text>
+                </Gradient>
+                <Text color="yellow">   Interactive Mode</Text>
+                <Text color="cyan">{' '.repeat(14)}║</Text>
+            </Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>██╔══╝  ██║╚██╔╝██║╚██╗ ██╔╝</Text>
+                </Gradient>
+                <Text color="cyan">{' '.repeat(33)}║</Text>
+            </Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>███████╗██║ ╚═╝ ██║ ╚████╔╝ </Text>
+                </Gradient>
+                <Text color="gray">   v2.0.0</Text>
+                <Text color="cyan">{' '.repeat(24)}║</Text>
+            </Text>
+            <Text bold>
+                <Text color="cyan">║  </Text>
+                <Gradient name="pastel">
+                    <Text>╚══════╝╚═╝     ╚═╝  ╚═══╝  </Text>
+                </Gradient>
+                <Text color="cyan">{' '.repeat(33)}║</Text>
+            </Text>
+            <Text color="cyan" bold>║{' '.repeat(63)}║</Text>
+            <Gradient name="rainbow">
+                <Text bold>{'╚' + '═'.repeat(63) + '╝'}</Text>
+            </Gradient>
+        </Box>
+    );
+}
+
+function StatusBar({ message, type = 'info' }: { message: string; type?: 'info' | 'success' | 'warning' | 'error' }): React.JSX.Element {
+    const colors = {
+        info: 'blue',
+        success: 'green',
+        warning: 'yellow',
+        error: 'red',
+    } as const;
+    const icons = {
+        info: 'ℹ',
+        success: '✓',
+        warning: '⚠',
+        error: '✗',
+    };
+
+    return (
+        <Box marginY={1} paddingX={2}>
+            <Text color={colors[type]} bold>
+                {icons[type]}{' '}
+            </Text>
+            <Text color={colors[type]}>{message}</Text>
+        </Box>
+    );
+}
+
+function LoadingSpinner({ message }: { message: string }): React.JSX.Element {
+    return (
+        <Box marginY={1} paddingX={2}>
+            <Text color="cyan">
+                <Spinner type="dots" />
+            </Text>
+            <Text color="cyan"> {message}</Text>
+        </Box>
+    );
+}
+
+function KeyHint({ keys, description }: { keys: string; description: string }): React.JSX.Element {
+    return (
+        <Box marginRight={2}>
+            <Text color="yellow" bold>
+                [{keys}]
+            </Text>
+            <Text color="gray"> {description}</Text>
+        </Box>
+    );
+}
+
+function Footer({ hints }: { hints: { keys: string; description: string }[] }): React.JSX.Element {
+    return (
+        <Box marginTop={1} paddingX={2} flexWrap="wrap">
+            {hints.map((hint, index) => (
+                <KeyHint key={index} keys={hint.keys} description={hint.description} />
+            ))}
+        </Box>
+    );
+}
+
+function CardBox({ title, children }: { title: string; children: React.ReactNode }): React.JSX.Element {
+    return (
+        <Box flexDirection="column" marginY={1} paddingX={2}>
+            <Box marginBottom={1}>
+                <Text color="magenta" bold>
+                    ┌─ {title} ─
+                </Text>
+            </Box>
+            <Box flexDirection="column" paddingLeft={2}>
+                {children}
+            </Box>
+        </Box>
+    );
+}
+
+// ============================================================================
+// Screen Components
+// ============================================================================
+
+interface WelcomeScreenProps {
+    onContinue: () => void;
+}
+
+function WelcomeScreen({ onContinue }: WelcomeScreenProps): React.JSX.Element {
+    useInput((input, key) => {
+        if (key.return || input === ' ') {
+            onContinue();
+        }
+    });
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="Welcome">
+                <Text>
+                    Welcome to the <Text color="cyan" bold>EMV Interactive Explorer</Text>!
+                </Text>
+                <Text> </Text>
+                <Text color="gray">
+                    This tool lets you explore EMV chip cards connected via PC/SC readers.
+                </Text>
+                <Text color="gray">
+                    You can discover applications, read card data, and verify PINs.
+                </Text>
+            </CardBox>
+            <Footer hints={[{ keys: 'Enter', description: 'Start' }, { keys: 'q', description: 'Quit' }]} />
+        </Box>
+    );
+}
+
+interface ReadersScreenProps {
+    readers: ReaderInfo[];
+    onSelect: (reader: ReaderInfo) => void;
+    onRefresh: () => void;
+    loading: boolean;
+}
+
+function ReadersScreen({ readers, onSelect, onRefresh, loading }: ReadersScreenProps): React.JSX.Element {
+    useInput((input) => {
+        if (input === 'r') {
+            onRefresh();
+        }
+    });
+
+    if (loading) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <LoadingSpinner message="Scanning for card readers..." />
+            </Box>
+        );
+    }
+
+    if (readers.length === 0) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <StatusBar message="No card readers found. Connect a reader and press 'r' to refresh." type="warning" />
+                <Footer hints={[{ keys: 'r', description: 'Refresh' }, { keys: 'q', description: 'Quit' }]} />
+            </Box>
+        );
+    }
+
+    const items = readers.map((reader) => {
+        const hasCard = (reader.state & SCARD_STATE_PRESENT) !== 0;
+        const icon = hasCard ? '💳' : '📖';
+        const status = hasCard ? ' (card present)' : '';
+        return {
+            key: reader.name,
+            label: `${icon}  ${reader.name}${status}`,
+            value: reader,
+        };
+    });
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="Select a Card Reader">
+                <SelectInput
+                    items={items}
+                    onSelect={(item) => { onSelect(item.value); }}
+                    itemComponent={({ isSelected, label }) =>
+                        isSelected ? (
+                            <Text color="cyan" bold>
+                                {'▸ '}
+                                {label}
+                            </Text>
+                        ) : (
+                            <Text>
+                                {'  '}
+                                {label}
+                            </Text>
+                        )
+                    }
+                />
+            </CardBox>
+            <Footer hints={[{ keys: '↑↓', description: 'Navigate' }, { keys: 'Enter', description: 'Select' }, { keys: 'r', description: 'Refresh' }, { keys: 'q', description: 'Quit' }]} />
+        </Box>
+    );
+}
+
+interface WaitingScreenProps {
+    readerName: string;
+}
+
+function WaitingScreen({ readerName }: WaitingScreenProps): React.JSX.Element {
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="Waiting for Card">
+                <Text color="gray">Reader: {readerName}</Text>
+                <Text> </Text>
+                <LoadingSpinner message="Insert a card to continue..." />
+            </CardBox>
+            <Footer hints={[{ keys: 'Esc', description: 'Back' }, { keys: 'q', description: 'Quit' }]} />
+        </Box>
+    );
+}
+
+interface AppsScreenProps {
+    apps: AppInfo[];
+    readerName: string;
+    atr: string;
+    onSelect: (app: AppInfo) => void;
+    onBack: () => void;
+    loading: boolean;
+}
+
+function AppsScreen({ apps, readerName, atr, onSelect, onBack, loading }: AppsScreenProps): React.JSX.Element {
+    useInput((_input, key) => {
+        if (key.escape) {
+            onBack();
+        }
+    });
+
+    if (loading) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <LoadingSpinner message="Reading card applications..." />
+            </Box>
+        );
+    }
+
+    if (apps.length === 0) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <CardBox title="Card Information">
+                    <Text color="gray">Reader: {readerName}</Text>
+                    <Text color="gray">ATR: {atr}</Text>
+                </CardBox>
+                <StatusBar message="No applications found on this card." type="warning" />
+                <Footer hints={[{ keys: 'Esc', description: 'Back' }, { keys: 'q', description: 'Quit' }]} />
+            </Box>
+        );
+    }
+
+    const items = apps.map((app) => ({
+        key: app.aid,
+        label: `${app.label ?? 'Unknown'} (${app.aid})`,
+        value: app,
+    }));
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="Card Information">
+                <Text color="gray">Reader: {readerName}</Text>
+                <Text color="gray">ATR: {atr}</Text>
+            </CardBox>
+            <CardBox title="Select an Application">
+                <SelectInput
+                    items={items}
+                    onSelect={(item) => { onSelect(item.value); }}
+                    itemComponent={({ isSelected, label }) =>
+                        isSelected ? (
+                            <Text color="cyan" bold>
+                                {'▸ '}
+                                {label}
+                            </Text>
+                        ) : (
+                            <Text>
+                                {'  '}
+                                {label}
+                            </Text>
+                        )
+                    }
+                />
+            </CardBox>
+            <Footer hints={[{ keys: '↑↓', description: 'Navigate' }, { keys: 'Enter', description: 'Select' }, { keys: 'Esc', description: 'Back' }, { keys: 'q', description: 'Quit' }]} />
+        </Box>
+    );
+}
+
+interface SelectedAppScreenProps {
+    app: AppInfo;
+    onVerifyPin: () => void;
+    onExplore: () => void;
+    onBack: () => void;
+}
+
+function SelectedAppScreen({ app, onVerifyPin, onExplore, onBack }: SelectedAppScreenProps): React.JSX.Element {
+    const items = [
+        { label: '🔐  Verify PIN', value: 'pin' },
+        { label: '🔍  Explore Card Data', value: 'explore' },
+        { label: '←   Back to Applications', value: 'back' },
+    ];
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="Selected Application">
+                <Text>
+                    <Text color="cyan" bold>Name: </Text>
+                    <Text>{app.label ?? 'Unknown'}</Text>
+                </Text>
+                <Text>
+                    <Text color="cyan" bold>AID: </Text>
+                    <Text color="yellow">{app.aid}</Text>
+                </Text>
+                {app.priority !== undefined && (
+                    <Text>
+                        <Text color="cyan" bold>Priority: </Text>
+                        <Text>{app.priority}</Text>
+                    </Text>
+                )}
+            </CardBox>
+            <CardBox title="Actions">
+                <SelectInput
+                    items={items}
+                    onSelect={(item) => {
+                        switch (item.value) {
+                            case 'pin':
+                                onVerifyPin();
+                                break;
+                            case 'explore':
+                                onExplore();
+                                break;
+                            case 'back':
+                                onBack();
+                                break;
+                        }
+                    }}
+                    itemComponent={({ isSelected, label }) =>
+                        isSelected ? (
+                            <Text color="cyan" bold>
+                                {'▸ '}
+                                {label}
+                            </Text>
+                        ) : (
+                            <Text>
+                                {'  '}
+                                {label}
+                            </Text>
+                        )
+                    }
+                />
+            </CardBox>
+            <Footer hints={[{ keys: '↑↓', description: 'Navigate' }, { keys: 'Enter', description: 'Select' }, { keys: 'q', description: 'Quit' }]} />
+        </Box>
+    );
+}
+
+interface PinScreenProps {
+    onSubmit: (pin: string) => void;
+    onBack: () => void;
+    loading: boolean;
+    attemptsLeft: number | undefined;
+}
+
+function PinScreen({ onSubmit, onBack, loading, attemptsLeft }: PinScreenProps): React.JSX.Element {
+    const [pin, setPin] = useState('');
+    const { isRawModeSupported } = useStdin();
+
+    useInput((_input, key) => {
+        if (key.escape) {
+            onBack();
+        }
+    });
+
+    const handleSubmit = useCallback((value: string) => {
+        if (value.length >= 4 && value.length <= 12 && /^\d+$/.test(value)) {
+            onSubmit(value);
+        }
+    }, [onSubmit]);
+
+    if (loading) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <LoadingSpinner message="Verifying PIN..." />
+            </Box>
+        );
+    }
+
+    const maskedPin = '•'.repeat(pin.length);
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="PIN Verification">
+                {attemptsLeft !== undefined && attemptsLeft < 3 && (
+                    <Box marginBottom={1}>
+                        <Text color="yellow" bold>
+                            ⚠ Warning: {attemptsLeft} attempt{attemptsLeft !== 1 ? 's' : ''} remaining!
+                        </Text>
+                    </Box>
+                )}
+                <Text color="gray">Enter your 4-12 digit PIN:</Text>
+                <Text> </Text>
+                <Box>
+                    <Text color="cyan" bold>PIN: </Text>
+                    {isRawModeSupported ? (
+                        <Box>
+                            <Text color="yellow">{maskedPin}</Text>
+                            <TextInput
+                                value={pin}
+                                onChange={setPin}
+                                onSubmit={handleSubmit}
+                                mask="•"
+                            />
+                        </Box>
+                    ) : (
+                        <Text color="gray">(raw mode not supported)</Text>
+                    )}
+                </Box>
+                <Text> </Text>
+                <Text color="gray" dimColor>
+                    PIN is sent in plaintext - use only with test cards!
+                </Text>
+            </CardBox>
+            <Footer hints={[{ keys: 'Enter', description: 'Submit' }, { keys: 'Esc', description: 'Back' }]} />
+        </Box>
+    );
+}
+
+interface PinResultScreenProps {
+    success: boolean;
+    message: string;
+    attemptsLeft: number | undefined;
+    onContinue: () => void;
+}
+
+function PinResultScreen({ success, message, attemptsLeft, onContinue }: PinResultScreenProps): React.JSX.Element {
+    useInput((input, key) => {
+        if (key.return || input === ' ') {
+            onContinue();
+        }
+    });
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title="PIN Verification Result">
+                {success ? (
+                    <Box flexDirection="column">
+                        <Text color="green" bold>
+                            ✓ {message}
+                        </Text>
+                        <Text> </Text>
+                        <Box>
+                            <Text color="green">🎉 </Text>
+                            <Gradient name="rainbow">
+                                <Text bold>PIN Verified Successfully!</Text>
+                            </Gradient>
+                        </Box>
+                    </Box>
+                ) : (
+                    <Box flexDirection="column">
+                        <Text color="red" bold>
+                            ✗ {message}
+                        </Text>
+                        {attemptsLeft !== undefined && (
+                            <Text color="yellow">
+                                Attempts remaining: {attemptsLeft}
+                            </Text>
+                        )}
+                    </Box>
+                )}
+            </CardBox>
+            <Footer hints={[{ keys: 'Enter', description: 'Continue' }]} />
+        </Box>
+    );
+}
+
+interface ExploreScreenProps {
+    emv: EmvApplication;
+    app: AppInfo;
+    onBack: () => void;
+}
+
+function ExploreScreen({ emv, app, onBack }: ExploreScreenProps): React.JSX.Element {
+    const [loading, setLoading] = useState(false);
+    const [data, setData] = useState<{ tag: string; name: string; value: string }[]>([]);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedAction, setSelectedAction] = useState<string | null>(null);
+
+    useInput((_input, key) => {
+        if (key.escape) {
+            if (selectedAction) {
+                setSelectedAction(null);
+            } else {
+                onBack();
+            }
+        }
+    });
+
+    const fetchData = useCallback(async (action: string) => {
+        setLoading(true);
+        setError(null);
+        setData([]);
+
+        try {
+            switch (action) {
+                case 'gpo': {
+                    const response = await emv.getProcessingOptions();
+                    if (response.isOk()) {
+                        setData([{ tag: 'GPO', name: 'GET_PROCESSING_OPTIONS', value: response.buffer.toString('hex') }]);
+                    } else {
+                        setError(`GET PROCESSING OPTIONS failed: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
+                    }
+                    break;
+                }
+                case 'records': {
+                    const records: { tag: string; name: string; value: string }[] = [];
+                    for (let sfi = 1; sfi <= 10; sfi++) {
+                        for (let rec = 1; rec <= 10; rec++) {
+                            const response = await emv.readRecord(sfi, rec);
+                            if (response.isOk()) {
+                                const formatted = formatTlv(response);
+                                records.push({
+                                    tag: `SFI${String(sfi)}:R${String(rec)}`,
+                                    name: 'RECORD',
+                                    value: formatted || response.buffer.toString('hex')
+                                });
+                            } else if (response.sw1 === 0x6a && response.sw2 === 0x83) {
+                                // Record not found, try next SFI
+                                break;
+                            }
+                        }
+                    }
+                    if (records.length === 0) {
+                        setError('No records found');
+                    } else {
+                        setData(records);
+                    }
+                    break;
+                }
+                case 'pincount': {
+                    const response = await emv.getData(0x9f17);
+                    if (response.isOk()) {
+                        const count = response.buffer[0];
+                        setData([{ tag: '9F17', name: 'PIN_TRY_COUNT', value: count !== undefined ? String(count) : 'Unknown' }]);
+                    } else {
+                        setError(`PIN try count not available: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
+                    }
+                    break;
+                }
+                case 'atc': {
+                    const response = await emv.getData(0x9f36);
+                    if (response.isOk()) {
+                        const atcValue = response.buffer.readUInt16BE(0);
+                        setData([{ tag: '9F36', name: 'APP_TRANSACTION_COUNTER', value: String(atcValue) }]);
+                    } else {
+                        setError(`ATC not available: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
+                    }
+                    break;
+                }
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setLoading(false);
+        }
+    }, [emv]);
+
+    const items = [
+        { label: '📊  Get Processing Options', value: 'gpo' },
+        { label: '📁  Read All Records', value: 'records' },
+        { label: '🔢  PIN Try Counter', value: 'pincount' },
+        { label: '🔄  Application Transaction Counter', value: 'atc' },
+        { label: '←   Back', value: 'back' },
+    ];
+
+    if (loading) {
+        return (
+            <Box flexDirection="column">
+                <Header />
+                <LoadingSpinner message="Reading card data..." />
+            </Box>
+        );
+    }
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <CardBox title={`Exploring: ${app.label ?? app.aid}`}>
+                {error && <StatusBar message={error} type="error" />}
+                {data.length > 0 && (
+                    <Box flexDirection="column" marginBottom={1}>
+                        {data.map((item, i) => (
+                            <Box key={i} flexDirection="column" marginBottom={1}>
+                                <Text color="cyan" bold>
+                                    {item.tag} ({item.name}):
+                                </Text>
+                                <Text color="yellow" wrap="wrap">
+                                    {item.value}
+                                </Text>
+                            </Box>
+                        ))}
+                    </Box>
+                )}
+                <SelectInput
+                    items={items}
+                    onSelect={(item) => {
+                        if (item.value === 'back') {
+                            onBack();
+                        } else {
+                            setSelectedAction(item.value);
+                            void fetchData(item.value);
+                        }
+                    }}
+                    itemComponent={({ isSelected, label }) =>
+                        isSelected ? (
+                            <Text color="cyan" bold>
+                                {'▸ '}
+                                {label}
+                            </Text>
+                        ) : (
+                            <Text>
+                                {'  '}
+                                {label}
+                            </Text>
+                        )
+                    }
+                />
+            </CardBox>
+            <Footer hints={[{ keys: '↑↓', description: 'Navigate' }, { keys: 'Enter', description: 'Select' }, { keys: 'Esc', description: 'Back' }]} />
+        </Box>
+    );
+}
+
+interface ErrorScreenProps {
+    message: string;
+    onBack: () => void;
+}
+
+function ErrorScreen({ message, onBack }: ErrorScreenProps): React.JSX.Element {
+    useInput((input, key) => {
+        if (key.return || key.escape || input === ' ') {
+            onBack();
+        }
+    });
+
+    return (
+        <Box flexDirection="column">
+            <Header />
+            <StatusBar message={message} type="error" />
+            <Footer hints={[{ keys: 'Enter', description: 'Back' }]} />
+        </Box>
+    );
+}
+
+// ============================================================================
+// Main App
+// ============================================================================
+
+function App(): React.JSX.Element {
+    const { exit } = useApp();
+    const [screen, setScreen] = useState<Screen>('welcome');
+    const [readers, setReaders] = useState<ReaderInfo[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [selectedReader, setSelectedReader] = useState<ReaderInfo | null>(null);
+    const [devices, setDevices] = useState<DevicesLike | null>(null);
+    const [emv, setEmv] = useState<EmvApplication | null>(null);
+    const [apps, setApps] = useState<AppInfo[]>([]);
+    const [atr, setAtr] = useState('');
+    const [selectedApp, setSelectedApp] = useState<AppInfo | null>(null);
+    const [pinLoading, setPinLoading] = useState(false);
+    const [pinResult, setPinResult] = useState<{ success: boolean; message: string; attemptsLeft?: number } | null>(null);
+    const [pinAttemptsLeft, setPinAttemptsLeft] = useState<number | undefined>(undefined);
+    const [error, setError] = useState<string | null>(null);
+
+    // Handle quit
+    useInput((input) => {
+        if (input === 'q') {
+            if (devices) {
+                devices.stop();
+            }
+            exit();
+        }
+    });
+
+    // Initialize devices
+    useEffect(() => {
+        let mounted = true;
+
+        const initDevices = async () => {
+            try {
+                const { Devices } = await import('smartcard');
+                const d = new Devices() as DevicesLike;
+                if (mounted) {
+                    setDevices(d);
+                }
+            } catch {
+                if (mounted) {
+                    setError('Failed to initialize PC/SC. Is pcscd running?');
+                    setScreen('error');
+                }
+            }
+        };
+
+        void initDevices();
+
+        return () => {
+            mounted = false;
+        };
+    }, []);
+
+    // Refresh readers
+    const refreshReaders = useCallback(() => {
+        if (!devices) return;
+
+        setLoading(true);
+        devices.start();
+
+        setTimeout(() => {
+            const readerList = devices.listReaders();
+            setReaders(readerList);
+            setLoading(false);
+        }, 200);
+    }, [devices]);
+
+    // Helper function to read apps from a card
+    const readAppsFromCard = useCallback(async (readerName: string, card: CardInfo) => {
+        setLoading(true);
+        setScreen('apps');
+
+        try {
+            const { EmvApplication: EmvApp } = await import('./emv-application.js');
+            const emvApp = new EmvApp(
+                { name: readerName },
+                card as unknown as import('./types.js').SmartCard
+            );
+            setEmv(emvApp);
+            setAtr(card.atr?.toString('hex') ?? '');
+
+            // Read apps from PSE
+            const pseResponse = await emvApp.selectPse();
+            if (pseResponse.isOk()) {
+                const sfiData = findTagInBuffer(pseResponse.buffer, 0x88);
+                const sfi = sfiData?.[0] ?? 1;
+                const appList: AppInfo[] = [];
+
+                for (let record = 1; record <= 10; record++) {
+                    const response = await emvApp.readRecord(sfi, record);
+                    if (!response.isOk()) break;
+
+                    const aid = findTagInBuffer(response.buffer, 0x4f);
+                    if (aid) {
+                        const label = findTagInBuffer(response.buffer, 0x50);
+                        const priority = findTagInBuffer(response.buffer, 0x87);
+                        appList.push({
+                            aid: aid.toString('hex'),
+                            label: label?.toString('ascii'),
+                            priority: priority?.[0],
+                        });
+                    }
+                }
+                setApps(appList);
+            }
+            setLoading(false);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setScreen('error');
+            setLoading(false);
+        }
+    }, []);
+
+    // Handle reader selection
+    const handleReaderSelect = useCallback((reader: ReaderInfo) => {
+        setSelectedReader(reader);
+        const hasCard = (reader.state & SCARD_STATE_PRESENT) !== 0;
+
+        if (hasCard && devices) {
+            // Get the already-connected card directly from the library
+            const card = devices.getCard(reader.name);
+            if (card) {
+                void readAppsFromCard(reader.name, card);
+            } else {
+                // Card present but not yet connected - wait for card-inserted event
+                setLoading(true);
+                setScreen('apps');
+
+                const handleCardInserted = (event: unknown): void => {
+                    const cardEvent = event as CardInsertedEvent;
+                    if (cardEvent.reader.name === reader.name) {
+                        devices.off('card-inserted', handleCardInserted);
+                        void readAppsFromCard(reader.name, cardEvent.card);
+                    }
+                };
+                devices.on('card-inserted', handleCardInserted);
+            }
+        } else {
+            // Wait for card insertion
+            setScreen('waiting');
+
+            if (devices) {
+                const handleCardInserted = (event: unknown): void => {
+                    const cardEvent = event as CardInsertedEvent;
+                    if (cardEvent.reader.name === reader.name) {
+                        devices.off('card-inserted', handleCardInserted);
+                        void readAppsFromCard(reader.name, cardEvent.card);
+                    }
+                };
+                devices.on('card-inserted', handleCardInserted);
+            }
+        }
+    }, [devices, readAppsFromCard]);
+
+    // Handle app selection
+    const handleAppSelect = useCallback(async (app: AppInfo) => {
+        if (!emv) return;
+
+        setSelectedApp(app);
+        setLoading(true);
+
+        try {
+            const aidBuffer = Buffer.from(app.aid, 'hex');
+            await emv.selectApplication(aidBuffer);
+            setScreen('selected');
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setScreen('error');
+        } finally {
+            setLoading(false);
+        }
+    }, [emv]);
+
+    // Handle PIN verification
+    const handlePinSubmit = useCallback(async (pin: string) => {
+        if (!emv) return;
+
+        setPinLoading(true);
+
+        try {
+            const response = await emv.verifyPin(pin);
+
+            if (response.isOk()) {
+                setPinResult({ success: true, message: 'PIN verified successfully!' });
+            } else if (response.sw1 === 0x63 && (response.sw2 & 0xf0) === 0xc0) {
+                const attempts = response.sw2 & 0x0f;
+                setPinAttemptsLeft(attempts);
+                setPinResult({ success: false, message: 'Wrong PIN.', attemptsLeft: attempts });
+            } else if (response.sw1 === 0x69 && response.sw2 === 0x83) {
+                setPinResult({ success: false, message: 'PIN is blocked! Card cannot be used.' });
+            } else {
+                setPinResult({ success: false, message: `Verification failed: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}` });
+            }
+            setScreen('pin-result');
+        } catch (err) {
+            setPinResult({ success: false, message: err instanceof Error ? err.message : String(err) });
+            setScreen('pin-result');
+        } finally {
+            setPinLoading(false);
+        }
+    }, [emv]);
+
+    // Render current screen
+    switch (screen) {
+        case 'welcome':
+            return (
+                <WelcomeScreen
+                    onContinue={() => {
+                        setScreen('readers');
+                        refreshReaders();
+                    }}
+                />
+            );
+
+        case 'readers':
+            return (
+                <ReadersScreen
+                    readers={readers}
+                    onSelect={handleReaderSelect}
+                    onRefresh={refreshReaders}
+                    loading={loading}
+                />
+            );
+
+        case 'waiting':
+            return <WaitingScreen readerName={selectedReader?.name ?? 'Unknown'} />;
+
+        case 'apps':
+            return (
+                <AppsScreen
+                    apps={apps}
+                    readerName={selectedReader?.name ?? 'Unknown'}
+                    atr={atr}
+                    onSelect={(app) => void handleAppSelect(app)}
+                    onBack={() => { setScreen('readers'); }}
+                    loading={loading}
+                />
+            );
+
+        case 'selected':
+            return selectedApp ? (
+                <SelectedAppScreen
+                    app={selectedApp}
+                    onVerifyPin={() => { setScreen('pin'); }}
+                    onExplore={() => { setScreen('explore'); }}
+                    onBack={() => { setScreen('apps'); }}
+                />
+            ) : (
+                <ErrorScreen message="No app selected" onBack={() => { setScreen('apps'); }} />
+            );
+
+        case 'pin':
+            return (
+                <PinScreen
+                    onSubmit={(pin) => void handlePinSubmit(pin)}
+                    onBack={() => { setScreen('selected'); }}
+                    loading={pinLoading}
+                    attemptsLeft={pinAttemptsLeft}
+                />
+            );
+
+        case 'pin-result':
+            return pinResult ? (
+                <PinResultScreen
+                    success={pinResult.success}
+                    message={pinResult.message}
+                    attemptsLeft={pinResult.attemptsLeft}
+                    onContinue={() => { setScreen('selected'); }}
+                />
+            ) : (
+                <ErrorScreen message="No result" onBack={() => { setScreen('selected'); }} />
+            );
+
+        case 'explore':
+            return emv && selectedApp ? (
+                <ExploreScreen emv={emv} app={selectedApp} onBack={() => { setScreen('selected'); }} />
+            ) : (
+                <ErrorScreen message="No EMV connection" onBack={() => { setScreen('selected'); }} />
+            );
+
+        case 'error':
+            return <ErrorScreen message={error ?? 'Unknown error'} onBack={() => { setScreen('readers'); }} />;
+
+        default:
+            return <ErrorScreen message="Unknown screen" onBack={() => { setScreen('welcome'); }} />;
+    }
+}
+
+// ============================================================================
+// Entry Point
+// ============================================================================
+
+export function runInteractive(): void {
+    render(<App />);
+}
+
+// Run if executed directly
+const isMainModule = process.argv[1]?.endsWith('interactive.js') ?? false;
+if (isMainModule) {
+    runInteractive();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "lib": ["ES2022"],
+        "jsx": "react-jsx",
+        "jsxImportSource": "react",
         "outDir": "./dist",
         "rootDir": "./src",
         "strict": true,


### PR DESCRIPTION
## Summary

Adds a new interactive mode to the EMV CLI that provides a beautiful terminal UI for exploring EMV chip cards.

### Features
- **Interactive mode as default** - Running `emv` with no arguments launches the interactive UI
- **Beautiful terminal UI** - Gradient header, card-based layouts, and status indicators
- **Reader selection** - Lists available PC/SC readers with card presence indicators
- **Application discovery** - Reads applications from PSE and displays them for selection
- **PIN verification** - Masked PIN input with attempt counter warnings
- **Card data exploration** - Read processing options, records, and counters

### Technical changes
- Add `src/interactive.tsx` - React/Ink-based interactive UI
- Update `src/cli.ts` to launch interactive mode when no command given
- Update smartcard to v3.5.0 for new `getCard()` API
- Add React, Ink, and related dependencies
- Add JSX support to TypeScript config

### Dependencies added
- react, react-devtools-core
- ink, ink-gradient, ink-select-input, ink-spinner, ink-text-input

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm test` passes (121 tests)
- [ ] Manual testing with card reader