### PR TITLE
Use smartcard's autoGetResponse for T=0 protocol handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "ink-spinner": "^5.0.0",
                 "ink-text-input": "^6.0.0",
                 "react": "^19.2.3",
-                "smartcard": "^3.0.0"
+                "smartcard": "^3.6.0"
             },
             "bin": {
                 "emv": "dist/cli.js"
@@ -2171,9 +2171,9 @@
             }
         },
         "node_modules/smartcard": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/smartcard/-/smartcard-3.5.0.tgz",
-            "integrity": "sha512-0GO1rPosz50WfsRbs8UZl/FrcLXtOndeyuoOQwHopKogx9ad9KEKaVMCXCIG+H0qZLIRLDR0RYE10La/6xpgIw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/smartcard/-/smartcard-3.6.0.tgz",
+            "integrity": "sha512-OOPt/8/uJcQWUXJLGOxWaK76LSANy5HNSxjTqTpLBMLeCSsgv7zmu9AxqQBYgSYUCPttu9CWR5Sg9+7iqvtu/g==",
             "hasInstallScript": true,
             "license": "MIT",
             "os": [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "react": "^19.2.3",
-        "smartcard": "^3.0.0"
+        "smartcard": "^3.6.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",

--- a/src/emv-application.test.ts
+++ b/src/emv-application.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import { EmvApplication, createEmvApplication } from './index.js';
-import type { Reader, SmartCard } from './types.js';
+import type { Reader, SmartCard, TransmitOptions } from './types.js';
+
+interface TransmitCall {
+    apdu: Buffer;
+    options: TransmitOptions | undefined;
+}
 
 describe('EmvApplication', () => {
     let emv: EmvApplication;
     let mockReader: Reader;
     let mockCard: SmartCard;
     let transmitCalls: Buffer[];
+    let transmitCallsWithOptions: TransmitCall[];
 
     beforeEach(() => {
         transmitCalls = [];
+        transmitCallsWithOptions = [];
         mockReader = { name: 'Test Reader' };
         mockCard = {
             atr: Buffer.from([0x3b, 0x8f, 0x80, 0x01]),
-            transmit: async (apdu) => {
-                transmitCalls.push(Buffer.isBuffer(apdu) ? apdu : Buffer.from(apdu));
+            transmit: async (apdu, options) => {
+                const buf = Buffer.isBuffer(apdu) ? apdu : Buffer.from(apdu);
+                transmitCalls.push(buf);
+                transmitCallsWithOptions.push({ apdu: buf, options });
                 return Buffer.from([0x6f, 0x00, 0x90, 0x00]);
             },
         };
@@ -504,131 +513,27 @@ describe('EmvApplication', () => {
     });
 
     describe('T=0 protocol handling', () => {
-        describe('SW1=61 (GET RESPONSE required)', () => {
-            it('should automatically send GET RESPONSE when SW1=61', async () => {
-                let callCount = 0;
-                mockCard.transmit = async (apdu) => {
-                    const buf = Buffer.isBuffer(apdu) ? apdu : Buffer.from(apdu);
-                    transmitCalls.push(buf);
-                    callCount++;
-                    if (callCount === 1) {
-                        // First call: return 61 1C (more data available, 28 bytes)
-                        return Buffer.from([0x61, 0x1c]);
-                    } else {
-                        // Second call (GET RESPONSE): return actual data
-                        return Buffer.from([
-                            0x6f, 0x1a, 0x84, 0x0e, 0x31, 0x50, 0x41, 0x59,
-                            0x2e, 0x53, 0x59, 0x53, 0x2e, 0x44, 0x44, 0x46,
-                            0x30, 0x31, 0xa5, 0x08, 0x88, 0x01, 0x01, 0x5f,
-                            0x2d, 0x02, 0x65, 0x6e, 0x90, 0x00
-                        ]);
-                    }
-                };
+        it('should pass autoGetResponse: true to smartcard transmit', async () => {
+            await emv.selectPse();
 
-                const response = await emv.selectPse();
-
-                // Should have made 2 transmit calls
-                assert.strictEqual(transmitCalls.length, 2);
-
-                // Second call should be GET RESPONSE (00 C0 00 00 1C)
-                const getResponseApdu = transmitCalls[1];
-                assert.ok(getResponseApdu);
-                assert.strictEqual(getResponseApdu[0], 0x00); // CLA
-                assert.strictEqual(getResponseApdu[1], 0xc0); // INS: GET RESPONSE
-                assert.strictEqual(getResponseApdu[2], 0x00); // P1
-                assert.strictEqual(getResponseApdu[3], 0x00); // P2
-                assert.strictEqual(getResponseApdu[4], 0x1c); // Le = 28 bytes
-
-                // Response should be successful with data
-                assert.strictEqual(response.isOk(), true);
-                assert.strictEqual(response.sw1, 0x90);
-                assert.strictEqual(response.sw2, 0x00);
-                assert.ok(response.buffer.length > 0);
-            });
-
-            it('should handle chained GET RESPONSE (multiple 61 XX)', async () => {
-                let callCount = 0;
-                mockCard.transmit = async () => {
-                    callCount++;
-                    if (callCount === 1) {
-                        // First response: data + 61 10
-                        return Buffer.from([0x6f, 0x0a, 0x84, 0x08, 0x61, 0x10]);
-                    } else if (callCount === 2) {
-                        // Second response: more data + 61 08
-                        return Buffer.from([0x01, 0x02, 0x03, 0x04, 0x61, 0x08]);
-                    } else {
-                        // Final response: remaining data + 90 00
-                        return Buffer.from([0x05, 0x06, 0x07, 0x08, 0x90, 0x00]);
-                    }
-                };
-
-                const response = await emv.selectPse();
-                assert.strictEqual(response.isOk(), true);
-                // Should combine all data parts
-                assert.strictEqual(response.buffer.toString('hex'), '6f0a84080102030405060708');
-            });
+            assert.strictEqual(transmitCallsWithOptions.length, 1);
+            const call = transmitCallsWithOptions[0];
+            assert.ok(call);
+            assert.deepStrictEqual(call.options, { autoGetResponse: true });
         });
 
-        describe('SW1=6C (wrong Le, retry with correct length)', () => {
-            it('should retry command with correct Le when SW1=6C', async () => {
-                let callCount = 0;
-                mockCard.transmit = async (apdu) => {
-                    const buf = Buffer.isBuffer(apdu) ? apdu : Buffer.from(apdu);
-                    transmitCalls.push(buf);
-                    callCount++;
-                    if (callCount === 1) {
-                        // First call: return 6C 59 (wrong Le, expected 89 bytes)
-                        return Buffer.from([0x6c, 0x59]);
-                    } else {
-                        // Second call with correct Le: return data
-                        return Buffer.from([
-                            0x70, 0x57, 0x61, 0x25, 0x4f, 0x07, 0xa0, 0x00,
-                            0x00, 0x00, 0x03, 0x10, 0x10, 0x50, 0x0a, 0x56,
-                            0x69, 0x73, 0x61, 0x20, 0x44, 0x65, 0x62, 0x69,
-                            0x74, 0x90, 0x00
-                        ]);
-                    }
-                };
+        it('should pass autoGetResponse for all APDU methods', async () => {
+            // Test multiple methods to ensure they all use autoGetResponse
+            await emv.selectPse();
+            await emv.selectApplication([0xa0, 0x00, 0x00, 0x00, 0x04]);
+            await emv.readRecord(1, 1);
+            await emv.getData(0x9f17);
+            await emv.getProcessingOptions();
 
-                const response = await emv.readRecord(1, 1);
-
-                // Should have made 2 transmit calls
-                assert.strictEqual(transmitCalls.length, 2);
-
-                // Second call should have Le = 0x59
-                const retryApdu = transmitCalls[1];
-                assert.ok(retryApdu);
-                assert.strictEqual(retryApdu[retryApdu.length - 1], 0x59);
-
-                // Response should be successful
-                assert.strictEqual(response.isOk(), true);
-                assert.ok(response.buffer.length > 0);
-            });
-        });
-
-        describe('combined SW1=6C and SW1=61 handling', () => {
-            it('should handle 6C followed by 61', async () => {
-                let callCount = 0;
-                mockCard.transmit = async (apdu) => {
-                    const buf = Buffer.isBuffer(apdu) ? apdu : Buffer.from(apdu);
-                    transmitCalls.push(buf);
-                    callCount++;
-                    if (callCount === 1) {
-                        // First: wrong Le
-                        return Buffer.from([0x6c, 0x20]);
-                    } else if (callCount === 2) {
-                        // Second: more data available
-                        return Buffer.from([0x61, 0x10]);
-                    } else {
-                        // Third: actual data
-                        return Buffer.from([0x6f, 0x0e, 0x84, 0x0c, 0x01, 0x02, 0x90, 0x00]);
-                    }
-                };
-
-                const response = await emv.selectPse();
-                assert.strictEqual(transmitCalls.length, 3);
-                assert.strictEqual(response.isOk(), true);
-            });
+            // All calls should have autoGetResponse: true
+            for (const call of transmitCallsWithOptions) {
+                assert.deepStrictEqual(call.options, { autoGetResponse: true });
+            }
         });
     });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,21 @@ export interface CardResponse {
 }
 
 /**
+ * Transmit options for smartcard package
+ */
+export interface TransmitOptions {
+    /** Automatically handle T=0 status words (SW1=61, SW1=6C) */
+    autoGetResponse?: boolean;
+}
+
+/**
  * Card interface from smartcard package
  */
 export interface SmartCard {
     /** Answer to Reset */
     atr: Buffer;
     /** Transmit APDU command to card */
-    transmit(apdu: Buffer | number[]): Promise<Buffer>;
+    transmit(apdu: Buffer | number[], options?: TransmitOptions): Promise<Buffer>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Simplifies the EMV library by delegating T=0 protocol status word handling to the smartcard package's new `autoGetResponse` feature (added in v3.6.0).

## Changes

- Update smartcard dependency to 3.6.0
- Remove custom `#transmitWithRetry` implementation (~50 lines)
- Remove `buildGetResponseApdu` helper function
- Add `TransmitOptions` interface to types
- Pass `{ autoGetResponse: true }` to all transmit calls
- Simplify tests to verify `autoGetResponse` is passed correctly

## Benefits

- Less code to maintain in the EMV library
- T=0 handling is now tested in the smartcard package
- Future improvements to T=0 handling benefit all smartcard users

## Test plan

- [x] All tests pass (123 tests)
- [x] Linter passes
- [ ] Manual test with contact card reader