### PR TITLE
Add formatter for Track 1 Discretionary Data (tag 9F1F)

### DIFF
--- a/src/emv-tags.test.ts
+++ b/src/emv-tags.test.ts
@@ -232,4 +232,18 @@ describe('format', () => {
         // Should NOT show garbage ASCII
         assert.ok(!result.includes('['), 'Should not show ASCII in brackets');
     });
+
+    it('should format Track 1 Discretionary Data with decoded ASCII on new line', () => {
+        // Tag 9F1F (TRACK_1_DD): ASCII-encoded discretionary data "205400932000000"
+        const response = createMockResponse(
+            Buffer.from([0x9f, 0x1f, 0x0f, 0x32, 0x30, 0x35, 0x34, 0x30, 0x30, 0x39, 0x33, 0x32, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30])
+        );
+        const result = format(response);
+        // Should show raw hex
+        assert.ok(result.includes('323035343030393332303030303030'), 'Should contain raw hex');
+        // Should show decoded ASCII value on new line (not in brackets)
+        assert.ok(result.includes('205400932000000'), 'Should contain decoded ASCII');
+        // Should NOT use bracket format
+        assert.ok(!result.includes('[205400932000000]'), 'Should not show ASCII in brackets');
+    });
 });

--- a/src/emv-tags.ts
+++ b/src/emv-tags.ts
@@ -294,6 +294,16 @@ function formatIacTvr(buffer: Buffer): string {
 }
 
 /**
+ * Format Track 1 Discretionary Data
+ * Shows hex with decoded ASCII below
+ */
+function formatTrack1Dd(buffer: Buffer): string {
+    const hex = buffer.toString('hex').toUpperCase();
+    const ascii = buffer.toString().replace(/[^\x20-\x7E]/g, '.');
+    return `${hex}\n      ${DIM}${ascii}${RESET}`;
+}
+
+/**
  * Get custom formatter for a specific tag
  */
 function getTagFormatter(tagNum: number): ((buffer: Buffer) => string) | undefined {
@@ -319,6 +329,8 @@ function getTagFormatter(tagNum: number): ((buffer: Buffer) => string) | undefin
         case 0x9f0f: // IAC_ONLINE
         case 0x95: // TVR
             return formatIacTvr;
+        case 0x9f1f: // TRACK_1_DD
+            return formatTrack1Dd;
         default:
             return undefined;
     }


### PR DESCRIPTION
## Summary

Adds human-readable formatting for Track 1 Discretionary Data (tag 9F1F).

## Changes

- Shows raw hex on first line
- Decoded ASCII value displayed below in dimmed text
- Consistent with other tag formatters

## Example output

Before:
```
9F1F (TRACK_1_DD): 323035343030393332303030303030 [205400932000000]
```

After:
```
9F1F (TRACK_1_DD): 323035343030393332303030303030
      205400932000000
```

## Test plan

- [x] Added unit test for Track 1 DD formatting
- [x] All 132 tests pass

Fixes #86