### PR TITLE
Fix PIN Try Counter and ATC parsing in interactive mode

### DIFF
--- a/src/interactive.tsx
+++ b/src/interactive.tsx
@@ -655,7 +655,8 @@ function ExploreScreen({ emv, app, onBack }: ExploreScreenProps): React.JSX.Elem
                 case 'pincount': {
                     const response = await emv.getData(0x9f17);
                     if (response.isOk()) {
-                        const count = response.buffer[0];
+                        const tagValue = findTagInBuffer(response.buffer, 0x9f17);
+                        const count = tagValue?.[0];
                         setData([{ tag: '9F17', name: 'PIN_TRY_COUNT', value: count !== undefined ? String(count) : 'Unknown' }]);
                     } else {
                         setError(`PIN try count not available: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
@@ -665,8 +666,9 @@ function ExploreScreen({ emv, app, onBack }: ExploreScreenProps): React.JSX.Elem
                 case 'atc': {
                     const response = await emv.getData(0x9f36);
                     if (response.isOk()) {
-                        const atcValue = response.buffer.readUInt16BE(0);
-                        setData([{ tag: '9F36', name: 'APP_TRANSACTION_COUNTER', value: String(atcValue) }]);
+                        const tagValue = findTagInBuffer(response.buffer, 0x9f36);
+                        const atcValue = tagValue && tagValue.length >= 2 ? tagValue.readUInt16BE(0) : undefined;
+                        setData([{ tag: '9F36', name: 'APP_TRANSACTION_COUNTER', value: atcValue !== undefined ? String(atcValue) : 'Unknown' }]);
                     } else {
                         setError(`ATC not available: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
                     }


### PR DESCRIPTION
## Summary

Fixes incorrect display of PIN Try Counter (showed 159 instead of actual value like 3) and Application Transaction Counter in the interactive UI.

## Root Cause

The code was reading `response.buffer[0]` directly, but the buffer contains the full TLV response (tag + length + value):

```
9F 17 01 03
^^ ^^ ^^ ^^
|  |  |  +-- value (3)
|  |  +-- length (1)
+--+-- tag (9F17)
```

So `buffer[0]` returned `0x9F` = 159, not the actual PIN try count.

## Fix

Use `findTagInBuffer()` to properly extract the tag value from the TLV response.

## Test plan

- [x] All 136 tests pass
- [ ] Manual testing with real card

Fixes #90