### PR TITLE
Add GPO response formatter and revert PIN counter pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { EmvApplication, createEmvApplication, default } from './emv-application.js';
-export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName } from './emv-tags.js';
+export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName, formatGpoResponse } from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';

--- a/src/interactive.tsx
+++ b/src/interactive.tsx
@@ -11,7 +11,7 @@ import SelectInput from 'ink-select-input';
 import TextInput from 'ink-text-input';
 import Gradient from 'ink-gradient';
 import { EmvApplication } from './emv-application.js';
-import { format as formatTlv, findTagInBuffer } from './emv-tags.js';
+import { format as formatTlv, findTagInBuffer, formatGpoResponse } from './emv-tags.js';
 
 // ============================================================================
 // Types
@@ -621,7 +621,8 @@ function ExploreScreen({ emv, app, onBack }: ExploreScreenProps): React.JSX.Elem
                 case 'gpo': {
                     const response = await emv.getProcessingOptions();
                     if (response.isOk()) {
-                        setData([{ tag: 'GPO', name: 'GET_PROCESSING_OPTIONS', value: response.buffer.toString('hex') }]);
+                        const formatted = formatGpoResponse(response.buffer);
+                        setData([{ tag: 'GPO', name: 'GET_PROCESSING_OPTIONS', value: formatted }]);
                     } else {
                         setError(`GET PROCESSING OPTIONS failed: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);
                     }
@@ -656,7 +657,7 @@ function ExploreScreen({ emv, app, onBack }: ExploreScreenProps): React.JSX.Elem
                     const response = await emv.getData(0x9f17);
                     if (response.isOk()) {
                         const tagValue = findTagInBuffer(response.buffer, 0x9f17);
-                        const count = tagValue && tagValue.length >= 1 ? tagValue[0] : undefined;
+                        const count = tagValue?.[0];
                         setData([{ tag: '9F17', name: 'PIN_TRY_COUNT', value: count !== undefined ? String(count) : 'Unknown' }]);
                     } else {
                         setError(`PIN try count not available: SW=${response.sw1.toString(16)}${response.sw2.toString(16)}`);


### PR DESCRIPTION
## Summary
- Add `formatGpoResponse()` function to decode GPO Format 1 responses with AIP and AFL
- Decode AIP (Application Interchange Profile) with bit meanings (SDA, DDA, CDA support, etc.)
- Decode AFL (Application File Locator) showing SFI and record ranges
- Update interactive UI to use formatted GPO display
- Revert PIN counter to use optional chaining pattern (`tagValue?.[0]`) per Copilot's suggestion on #92

This addresses the Copilot feedback that noted array access with `?.[0]` is already safe (returns undefined for out-of-bounds) and doesn't need explicit length checks.

## Test plan
- [x] All existing tests pass
- [x] Added tests for `formatGpoResponse` to verify AIP and AFL decoding
- [x] GPO Format 1 responses are properly decoded with human-readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)