### PR TITLE
Add automatic AFL record reading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData } from './emv-application.js';
-export type { AflEntry, DolEntry, TransactionOptions, TransactionResult } from './emv-application.js';
+export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData } from './emv-application.js';
 export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName, formatGpoResponse } from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';


### PR DESCRIPTION
## Summary
- Adds `readAllRecords(afl)` method to EmvApplication
- Accepts both `AflEntry[]` array or raw AFL `Buffer`
- Returns records with SFI and record number metadata
- Skips failed records gracefully

## Implementation
The method automates the iteration through AFL entries and reads all specified records. Records that fail to read are silently skipped (they may not exist on all cards).

## New Types
- `RecordData` interface with `sfi`, `recordNumber`, and `data` fields

## Test plan
- [x] All existing tests pass
- [x] Test reading from AFL entries array
- [x] Test reading from raw AFL buffer
- [x] Test skipping failed records
- [x] Test empty AFL handling

Closes #100