### PR TITLE
Add PDOL/CDOL builder utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData } from './emv-application.js';
-export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData } from './emv-application.js';
+export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData, buildDefaultPdolData, buildDefaultCdolData } from './emv-application.js';
+export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData, PdolBuildOptions, CdolBuildOptions } from './emv-application.js';
 export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName, formatGpoResponse } from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';


### PR DESCRIPTION
## Summary
- Adds `buildDefaultPdolData(entries, options)` for GPO with sensible defaults
- Adds `buildDefaultCdolData(options)` for Generate AC in standard field order
- Both support custom overrides via `Map<number, Buffer>`

## New Types
- `PdolBuildOptions` - options for PDOL building
- `CdolBuildOptions` - options for CDOL building

## Default Values
The builders provide sensible defaults for common tags:
- Amount (9F02) - from options
- Currency (5F2A) - from options
- Transaction Date (9A) - current date
- Unpredictable Number (9F37) - random
- Terminal Type (9F35) - standard POS
- CVM Results (9F34) - no CVM
- TVR (95) - all zeros

## Test plan
- [x] All existing tests pass
- [x] Tests for `buildDefaultPdolData` with various inputs
- [x] Tests for `buildDefaultCdolData` with transaction types
- [x] Tests for custom overrides

Closes #102