### PR TITLE
Add CVM (Cardholder Verification Method) parsing and evaluation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData, buildDefaultPdolData, buildDefaultCdolData } from './emv-application.js';
-export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData, PdolBuildOptions, CdolBuildOptions } from './emv-application.js';
+export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData, buildDefaultPdolData, buildDefaultCdolData, parseCvmList, evaluateCvm } from './emv-application.js';
+export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData, PdolBuildOptions, CdolBuildOptions, CvmMethod, CvmCondition, CvmRule, CvmList, CvmContext } from './emv-application.js';
 export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName, formatGpoResponse } from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';


### PR DESCRIPTION
## Summary
- Adds `parseCvmList()` function to parse EMV tag 8E (CVM List) data
- Adds `evaluateCvm()` function to select the appropriate verification method based on transaction context
- Supports all standard CVM conditions including terminal support, amount thresholds, cash transactions, etc.
- Exports new types: `CvmMethod`, `CvmCondition`, `CvmRule`, `CvmList`, `CvmContext`

## Test plan
- [x] Unit tests for `parseCvmList()` parsing various CVM list formats
- [x] Unit tests for `evaluateCvm()` with different contexts and conditions
- [x] All 172 tests pass
- [x] Lint checks pass

Closes #104