### PR TITLE
Add related packages section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ Tested with:
 - ACR122U (contactless)
 - Any PC/SC compatible reader
 
+## Related Packages
+
+If you're working with EMV or smartcard applications, these packages may be useful:
+
+- **[ber-tlv](https://github.com/tomkp/ber-tlv)** - BER-TLV encoding and decoding library. Useful if you need to work directly with TLV (Tag-Length-Value) structures, which are fundamental to EMV data encoding.
+
+- **[smartcard](https://github.com/tomkp/smartcard)** - PC/SC smartcard reader access for Node.js. This package provides the low-level communication layer for talking to smartcard readers, which this EMV library builds upon.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Adds a new "Related Packages" section to the README
- References `ber-tlv` and `smartcard` packages with explanations of why they may be useful

## Details
For developers exploring this EMV library, these related packages provide useful context:

- **ber-tlv**: Provides BER-TLV encoding/decoding, which is fundamental to EMV data structures
- **smartcard**: Provides the low-level PC/SC communication layer that this library builds upon

Closes #108