### PR TITLE
Fix PIN input displaying double asterisks for each digit

### DIFF
--- a/src/interactive.test.ts
+++ b/src/interactive.test.ts
@@ -1,11 +1,48 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Get the source directory (tests run from dist/, source is in src/)
+const srcDir = __dirname.replace(/\/dist$/, '/src');
 
 describe('Interactive CLI', () => {
     describe('module exports', () => {
         it('should export runInteractive function', async () => {
             const module = await import('./interactive.js');
             assert.strictEqual(typeof module.runInteractive, 'function');
+        });
+    });
+
+    describe('PinScreen component', () => {
+        it('should not render both manual maskedPin and TextInput with mask prop (causes double asterisks)', () => {
+            // Read the source file to check for the bug pattern
+            const sourceFile = join(srcDir, 'interactive.tsx');
+            const source = readFileSync(sourceFile, 'utf-8');
+
+            // Find the PinScreen function body
+            const pinScreenMatch = source.match(/function PinScreen\([^)]*\)[^{]*\{([\s\S]*?)^function /m);
+            assert.ok(pinScreenMatch, 'PinScreen function should exist');
+
+            const pinScreenBody = pinScreenMatch[1];
+
+            // Check if there's a maskedPin variable being rendered alongside TextInput with mask
+            const hasMaskedPinRendered = /\{maskedPin\}/.test(pinScreenBody ?? '');
+            const hasTextInputWithMask = /TextInput[\s\S]*?mask=/.test(pinScreenBody ?? '');
+
+            // The bug is when both maskedPin is rendered AND TextInput has mask prop
+            const hasBug = hasMaskedPinRendered && hasTextInputWithMask;
+
+            assert.strictEqual(
+                hasBug,
+                false,
+                'PinScreen should not render both maskedPin text and TextInput with mask prop - this causes double asterisks. ' +
+                    'Either remove the maskedPin rendering or remove the mask prop from TextInput.'
+            );
         });
     });
 });

--- a/src/interactive.tsx
+++ b/src/interactive.tsx
@@ -499,8 +499,6 @@ function PinScreen({ onSubmit, onBack, loading, attemptsLeft }: PinScreenProps):
         );
     }
 
-    const maskedPin = '•'.repeat(pin.length);
-
     return (
         <Box flexDirection="column">
             <Header />
@@ -517,15 +515,12 @@ function PinScreen({ onSubmit, onBack, loading, attemptsLeft }: PinScreenProps):
                 <Box>
                     <Text color="cyan" bold>PIN: </Text>
                     {isRawModeSupported ? (
-                        <Box>
-                            <Text color="yellow">{maskedPin}</Text>
-                            <TextInput
-                                value={pin}
-                                onChange={setPin}
-                                onSubmit={handleSubmit}
-                                mask="•"
-                            />
-                        </Box>
+                        <TextInput
+                            value={pin}
+                            onChange={setPin}
+                            onSubmit={handleSubmit}
+                            mask="•"
+                        />
                     ) : (
                         <Text color="gray">(raw mode not supported)</Text>
                     )}


### PR DESCRIPTION
## Summary
- Fixes bug where each PIN digit showed 2 asterisks instead of 1
- Removed redundant `maskedPin` text element - `TextInput` already handles masking via its `mask` prop
- Added regression test to prevent this from happening again

## Root Cause
The `PinScreen` component was rendering both:
1. A manually created `maskedPin` (`'•'.repeat(pin.length)`)
2. The `TextInput` component with `mask="•"`

Both were displayed simultaneously, causing double masking.

## Test Plan
- [x] Added test that verifies PinScreen doesn't render both maskedPin and TextInput with mask
- [x] All existing tests pass

Fixes #113