### PR TITLE
Add isRawModeSupported prop to PinScreen for testability

### DIFF
--- a/src/interactive.tsx
+++ b/src/interactive.tsx
@@ -472,11 +472,14 @@ export interface PinScreenProps {
     onBack: () => void;
     loading: boolean;
     attemptsLeft: number | undefined;
+    /** Override raw mode detection for testing. If not provided, uses useStdin() hook. */
+    isRawModeSupported?: boolean;
 }
 
-function PinScreen({ onSubmit, onBack, loading, attemptsLeft }: PinScreenProps): React.JSX.Element {
+function PinScreen({ onSubmit, onBack, loading, attemptsLeft, isRawModeSupported: isRawModeProp }: PinScreenProps): React.JSX.Element {
     const [pin, setPin] = useState('');
-    const { isRawModeSupported } = useStdin();
+    const { isRawModeSupported: isRawModeFromStdin } = useStdin();
+    const isRawModeSupported = isRawModeProp ?? isRawModeFromStdin;
 
     useInput((_input, key) => {
         if (key.escape) {


### PR DESCRIPTION
## Summary
- Add optional `isRawModeSupported` prop to `PinScreen` component for testing
- Component falls back to `useStdin()` hook when prop is not provided
- Add tests for PinScreen rendering with prop injection
- Ensure proper component cleanup with `unmount()` in tests

## Test plan
- [x] Run `npm test` - all 182 tests pass
- [x] Run `npm run lint` - no errors
- [x] Build succeeds