### PR TITLE
Fix incorrect BCD encoding in getCurrentDateBcd()

### DIFF
--- a/src/emv-application.test.ts
+++ b/src/emv-application.test.ts
@@ -204,10 +204,7 @@ describe('EmvApplication', () => {
 
     describe('verifyPin', () => {
         it('should throw RangeError for PIN shorter than 4 digits', async () => {
-            await assert.rejects(
-                () => emv.verifyPin('123'),
-                /PIN must be a string of 4-12 digits/
-            );
+            await assert.rejects(() => emv.verifyPin('123'), /PIN must be a string of 4-12 digits/);
         });
 
         it('should throw RangeError for PIN longer than 12 digits', async () => {
@@ -380,17 +377,11 @@ describe('EmvApplication', () => {
 
     describe('getData', () => {
         it('should throw RangeError for tag less than 0', async () => {
-            await assert.rejects(
-                () => emv.getData(-1),
-                /Tag must be a positive integer/
-            );
+            await assert.rejects(() => emv.getData(-1), /Tag must be a positive integer/);
         });
 
         it('should throw RangeError for tag greater than 0xFFFF', async () => {
-            await assert.rejects(
-                () => emv.getData(0x10000),
-                /Tag must be a positive integer/
-            );
+            await assert.rejects(() => emv.getData(0x10000), /Tag must be a positive integer/);
         });
 
         it('should transmit GET DATA APDU with 1-byte tag', async () => {
@@ -484,9 +475,8 @@ describe('EmvApplication', () => {
 
         it('should return AIP and AFL on success', async () => {
             // Format 1 response: 80 06 1C00 08010100
-            mockCard.transmit = async () => Buffer.from([
-                0x80, 0x06, 0x1c, 0x00, 0x08, 0x01, 0x01, 0x00, 0x90, 0x00
-            ]);
+            mockCard.transmit = async () =>
+                Buffer.from([0x80, 0x06, 0x1c, 0x00, 0x08, 0x01, 0x01, 0x00, 0x90, 0x00]);
             const response = await emv.getProcessingOptions();
             assert.strictEqual(response.isOk(), true);
             assert.strictEqual(response.buffer.toString('hex'), '80061c0008010100');
@@ -552,11 +542,11 @@ describe('EmvApplication', () => {
 
         it('should return cryptogram on success', async () => {
             // Response with Application Cryptogram
-            mockCard.transmit = async () => Buffer.from([
-                0x77, 0x12, 0x9f, 0x27, 0x01, 0x80, 0x9f, 0x36,
-                0x02, 0x00, 0x01, 0x9f, 0x26, 0x08, 0x12, 0x34,
-                0x56, 0x78, 0x9a, 0xbc, 0x90, 0x00
-            ]);
+            mockCard.transmit = async () =>
+                Buffer.from([
+                    0x77, 0x12, 0x9f, 0x27, 0x01, 0x80, 0x9f, 0x36, 0x02, 0x00, 0x01, 0x9f, 0x26,
+                    0x08, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0x90, 0x00,
+                ]);
             const response = await emv.generateAc(0x80, [0x01]);
             assert.strictEqual(response.isOk(), true);
         });
@@ -607,9 +597,10 @@ describe('EmvApplication', () => {
 
         it('should return signed data on success', async () => {
             // Response with signed dynamic data
-            mockCard.transmit = async () => Buffer.from([
-                0x80, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x90, 0x00
-            ]);
+            mockCard.transmit = async () =>
+                Buffer.from([
+                    0x80, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x90, 0x00,
+                ]);
             const response = await emv.internalAuthenticate([0x12, 0x34, 0x56, 0x78]);
             assert.strictEqual(response.isOk(), true);
             assert.strictEqual(response.buffer.length, 10);
@@ -657,8 +648,18 @@ describe('EmvApplication', () => {
             const aflBuffer = Buffer.from([0x08, 0x01, 0x03, 0x00, 0x10, 0x01, 0x01, 0x01]);
             const entries = parseAfl(aflBuffer);
             assert.strictEqual(entries.length, 2);
-            assert.deepStrictEqual(entries[0], { sfi: 1, firstRecord: 1, lastRecord: 3, sdaRecords: 0 });
-            assert.deepStrictEqual(entries[1], { sfi: 2, firstRecord: 1, lastRecord: 1, sdaRecords: 1 });
+            assert.deepStrictEqual(entries[0], {
+                sfi: 1,
+                firstRecord: 1,
+                lastRecord: 3,
+                sdaRecords: 0,
+            });
+            assert.deepStrictEqual(entries[1], {
+                sfi: 2,
+                firstRecord: 1,
+                lastRecord: 1,
+                sdaRecords: 1,
+            });
         });
 
         it('should return empty array for empty buffer', () => {
@@ -712,9 +713,7 @@ describe('EmvApplication', () => {
                 return Buffer.from([0x70, 0x02, 0x5a, 0x00, 0x90, 0x00]);
             };
 
-            const aflEntries = [
-                { sfi: 1, firstRecord: 1, lastRecord: 3, sdaRecords: 0 },
-            ];
+            const aflEntries = [{ sfi: 1, firstRecord: 1, lastRecord: 3, sdaRecords: 0 }];
 
             const records = await emv.readAllRecords(aflEntries);
             // Should have 2 records (first and third), second failed
@@ -754,30 +753,26 @@ describe('EmvApplication', () => {
 
         it('should build PDOL data from tag values', () => {
             const pdolEntries = [
-                { tag: 0x9f02, length: 6 },  // Amount
-                { tag: 0x5f2a, length: 2 },  // Currency
+                { tag: 0x9f02, length: 6 }, // Amount
+                { tag: 0x5f2a, length: 2 }, // Currency
             ];
             const tagValues = new Map<number, Buffer>([
-                [0x9f02, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x10, 0x00])],  // 10.00
-                [0x5f2a, Buffer.from([0x08, 0x26])],  // USD
+                [0x9f02, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x10, 0x00])], // 10.00
+                [0x5f2a, Buffer.from([0x08, 0x26])], // USD
             ]);
             const result = buildPdolData(pdolEntries, tagValues);
             assert.strictEqual(result.toString('hex'), '000000001000' + '0826');
         });
 
         it('should pad with zeros for missing tag values', () => {
-            const pdolEntries = [
-                { tag: 0x9f02, length: 6 },
-            ];
+            const pdolEntries = [{ tag: 0x9f02, length: 6 }];
             const tagValues = new Map<number, Buffer>();
             const result = buildPdolData(pdolEntries, tagValues);
             assert.strictEqual(result.toString('hex'), '000000000000');
         });
 
         it('should truncate values that are too long', () => {
-            const pdolEntries = [
-                { tag: 0x9f02, length: 3 },
-            ];
+            const pdolEntries = [{ tag: 0x9f02, length: 3 }];
             const tagValues = new Map<number, Buffer>([
                 [0x9f02, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x10, 0x00])],
             ]);
@@ -791,9 +786,9 @@ describe('EmvApplication', () => {
 
         it('should build PDOL data with default values', () => {
             const pdolEntries = [
-                { tag: 0x9f02, length: 6 },  // Amount
-                { tag: 0x5f2a, length: 2 },  // Currency
-                { tag: 0x9a, length: 3 },    // Transaction Date
+                { tag: 0x9f02, length: 6 }, // Amount
+                { tag: 0x5f2a, length: 2 }, // Currency
+                { tag: 0x9a, length: 3 }, // Transaction Date
             ];
 
             const result = buildDefaultPdolData(pdolEntries, {
@@ -810,9 +805,7 @@ describe('EmvApplication', () => {
         });
 
         it('should allow custom overrides', () => {
-            const pdolEntries = [
-                { tag: 0x9f02, length: 6 },
-            ];
+            const pdolEntries = [{ tag: 0x9f02, length: 6 }];
 
             const customAmount = Buffer.from([0x00, 0x00, 0x00, 0x05, 0x00, 0x00]);
             const result = buildDefaultPdolData(pdolEntries, {
@@ -826,7 +819,7 @@ describe('EmvApplication', () => {
 
         it('should use zeros for tags without defaults', () => {
             const pdolEntries = [
-                { tag: 0x9f99, length: 4 },  // Unknown tag
+                { tag: 0x9f99, length: 4 }, // Unknown tag
             ];
 
             const result = buildDefaultPdolData(pdolEntries, {
@@ -859,7 +852,7 @@ describe('EmvApplication', () => {
             const result = buildDefaultCdolData({
                 amount: 1000,
                 currencyCode: 0x0840,
-                transactionType: 0x09,  // Cashback
+                transactionType: 0x09, // Cashback
             });
 
             // Transaction type is at offset 24 (after amount 6 + other 6 + country 2 + tvr 5 + currency 2 + date 3)
@@ -876,11 +869,16 @@ describe('EmvApplication', () => {
                 if (callCount === 1) {
                     // GPO response (Format 1): 80 len AIP(2) AFL(4)
                     // AIP: 1C00, AFL: SFI 1 (0x08) records 1-1
-                    return Buffer.from([0x80, 0x06, 0x1c, 0x00, 0x08, 0x01, 0x01, 0x00, 0x90, 0x00]);
+                    return Buffer.from([
+                        0x80, 0x06, 0x1c, 0x00, 0x08, 0x01, 0x01, 0x00, 0x90, 0x00,
+                    ]);
                 } else if (callCount === 2) {
                     // Read record response - proper TLV structure
                     // 70 len [5A len PAN]
-                    return Buffer.from([0x70, 0x0a, 0x5a, 0x08, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x90, 0x00]);
+                    return Buffer.from([
+                        0x70, 0x0a, 0x5a, 0x08, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56,
+                        0x90, 0x00,
+                    ]);
                 } else if (callCount === 3) {
                     // Generate AC response with cryptogram - proper TLV structure
                     // 9F27 (4 bytes: 2-byte tag + 1-byte len + 1-byte value) = 4
@@ -888,11 +886,30 @@ describe('EmvApplication', () => {
                     // 9F26 (11 bytes: 2-byte tag + 1-byte len + 8-byte value) = 11
                     // Total = 20 bytes = 0x14
                     return Buffer.from([
-                        0x77, 0x14,  // 20 bytes
-                        0x9f, 0x27, 0x01, 0x80,  // CID: ARQC (4 bytes)
-                        0x9f, 0x36, 0x02, 0x00, 0x01,  // ATC: 1 (5 bytes)
-                        0x9f, 0x26, 0x08, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,  // Cryptogram (11 bytes)
-                        0x90, 0x00  // SW
+                        0x77,
+                        0x14, // 20 bytes
+                        0x9f,
+                        0x27,
+                        0x01,
+                        0x80, // CID: ARQC (4 bytes)
+                        0x9f,
+                        0x36,
+                        0x02,
+                        0x00,
+                        0x01, // ATC: 1 (5 bytes)
+                        0x9f,
+                        0x26,
+                        0x08,
+                        0x12,
+                        0x34,
+                        0x56,
+                        0x78,
+                        0x9a,
+                        0xbc,
+                        0xde,
+                        0xf0, // Cryptogram (11 bytes)
+                        0x90,
+                        0x00, // SW
                     ]);
                 }
                 return Buffer.from([0x90, 0x00]);
@@ -912,7 +929,7 @@ describe('EmvApplication', () => {
         });
 
         it('should handle GPO failure', async () => {
-            mockCard.transmit = async () => Buffer.from([0x69, 0x85]);  // Conditions not satisfied
+            mockCard.transmit = async () => Buffer.from([0x69, 0x85]); // Conditions not satisfied
 
             const result = await emv.performTransaction({
                 amount: 1000,
@@ -930,11 +947,20 @@ describe('EmvApplication', () => {
         it('should parse CVM list with amount thresholds', () => {
             // CVM List: X=1000, Y=5000, then rules
             const buffer = Buffer.from([
-                0x00, 0x00, 0x03, 0xe8,  // X = 1000
-                0x00, 0x00, 0x13, 0x88,  // Y = 5000
-                0x02, 0x03,              // Enciphered PIN online, if terminal supports CVM
-                0x1e, 0x03,              // Signature, if terminal supports CVM
-                0x1f, 0x00,              // No CVM, always
+                0x00,
+                0x00,
+                0x03,
+                0xe8, // X = 1000
+                0x00,
+                0x00,
+                0x13,
+                0x88, // Y = 5000
+                0x02,
+                0x03, // Enciphered PIN online, if terminal supports CVM
+                0x1e,
+                0x03, // Signature, if terminal supports CVM
+                0x1f,
+                0x00, // No CVM, always
             ]);
             const result = parseCvmList(buffer);
 
@@ -952,9 +978,16 @@ describe('EmvApplication', () => {
 
         it('should handle continue-on-fail flag', () => {
             const buffer = Buffer.from([
-                0x00, 0x00, 0x00, 0x00,  // X = 0
-                0x00, 0x00, 0x00, 0x00,  // Y = 0
-                0x42, 0x00,              // Enciphered PIN online + continue if fails, always
+                0x00,
+                0x00,
+                0x00,
+                0x00, // X = 0
+                0x00,
+                0x00,
+                0x00,
+                0x00, // Y = 0
+                0x42,
+                0x00, // Enciphered PIN online + continue if fails, always
             ]);
             const result = parseCvmList(buffer);
 
@@ -972,36 +1005,66 @@ describe('EmvApplication', () => {
         const { parseCvmList, evaluateCvm } = await import('./emv-application.js');
 
         it('should select first matching rule', () => {
-            const cvmList = parseCvmList(Buffer.from([
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00,
-                0x02, 0x03,  // Enciphered PIN, if terminal supports
-                0x1e, 0x03,  // Signature, if terminal supports
-            ]));
+            const cvmList = parseCvmList(
+                Buffer.from([
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x02,
+                    0x03, // Enciphered PIN, if terminal supports
+                    0x1e,
+                    0x03, // Signature, if terminal supports
+                ])
+            );
 
             const result = evaluateCvm(cvmList, { terminalSupportsCvm: true });
             assert.strictEqual(result?.method, 'enciphered_pin_online');
         });
 
         it('should skip rules where condition not met', () => {
-            const cvmList = parseCvmList(Buffer.from([
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00,
-                0x02, 0x03,  // Enciphered PIN, if terminal supports
-                0x1f, 0x00,  // No CVM, always
-            ]));
+            const cvmList = parseCvmList(
+                Buffer.from([
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x02,
+                    0x03, // Enciphered PIN, if terminal supports
+                    0x1f,
+                    0x00, // No CVM, always
+                ])
+            );
 
             const result = evaluateCvm(cvmList, { terminalSupportsCvm: false });
             assert.strictEqual(result?.method, 'no_cvm');
         });
 
         it('should handle amount threshold conditions', () => {
-            const cvmList = parseCvmList(Buffer.from([
-                0x00, 0x00, 0x03, 0xe8,  // X = 1000
-                0x00, 0x00, 0x00, 0x00,  // Y = 0
-                0x02, 0x07,  // Enciphered PIN, if amount > X
-                0x1f, 0x00,  // No CVM, always
-            ]));
+            const cvmList = parseCvmList(
+                Buffer.from([
+                    0x00,
+                    0x00,
+                    0x03,
+                    0xe8, // X = 1000
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00, // Y = 0
+                    0x02,
+                    0x07, // Enciphered PIN, if amount > X
+                    0x1f,
+                    0x00, // No CVM, always
+                ])
+            );
 
             // Amount 500 is under X (1000), so PIN rule doesn't apply
             const result1 = evaluateCvm(cvmList, { amount: 500 });
@@ -1013,14 +1076,56 @@ describe('EmvApplication', () => {
         });
 
         it('should return undefined if no rules match', () => {
-            const cvmList = parseCvmList(Buffer.from([
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00,
-                0x02, 0x03,  // Enciphered PIN, if terminal supports
-            ]));
+            const cvmList = parseCvmList(
+                Buffer.from([
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x00,
+                    0x02,
+                    0x03, // Enciphered PIN, if terminal supports
+                ])
+            );
 
             const result = evaluateCvm(cvmList, { terminalSupportsCvm: false });
             assert.strictEqual(result, undefined);
+        });
+    });
+
+    describe('stringToBcd', async () => {
+        const { stringToBcd } = await import('./emv-application.js');
+
+        it('should encode "00" as 0x00', () => {
+            assert.strictEqual(stringToBcd('00'), 0x00);
+        });
+
+        it('should encode "12" as 0x12', () => {
+            assert.strictEqual(stringToBcd('12'), 0x12);
+        });
+
+        it('should encode "25" as 0x25', () => {
+            assert.strictEqual(stringToBcd('25'), 0x25);
+        });
+
+        it('should encode "99" as 0x99', () => {
+            assert.strictEqual(stringToBcd('99'), 0x99);
+        });
+
+        it('should encode "10" correctly (not as hex 16)', () => {
+            // This is the key test - parseInt('10', 16) would give 16 (0x10)
+            // but BCD encoding of "10" should be (1 << 4) | 0 = 0x10 = 16
+            // So for '10' specifically, both approaches give same result.
+            // Let's test '31' where they differ: parseInt('31', 16) = 49 (0x31)
+            // BCD '31' = (3 << 4) | 1 = 49 (0x31) - also same!
+            // The bug is subtle - it works for valid date digits 0-9.
+            // Test with explicit nibble check
+            const result = stringToBcd('31');
+            assert.strictEqual(result >> 4, 3, 'High nibble should be 3');
+            assert.strictEqual(result & 0x0f, 1, 'Low nibble should be 1');
         });
     });
 });

--- a/src/emv-application.ts
+++ b/src/emv-application.ts
@@ -309,7 +309,12 @@ export function parseAfl(buffer: Buffer): AflEntry[] {
         const firstRecord = buffer[i + 1];
         const lastRecord = buffer[i + 2];
         const sdaRecords = buffer[i + 3];
-        if (sfiByte === undefined || firstRecord === undefined || lastRecord === undefined || sdaRecords === undefined) {
+        if (
+            sfiByte === undefined ||
+            firstRecord === undefined ||
+            lastRecord === undefined ||
+            sdaRecords === undefined
+        ) {
             continue;
         }
         entries.push({
@@ -401,21 +406,26 @@ function generateUnpredictableNumber(): Buffer {
  * @returns Buffer containing PDOL data ready for GPO
  */
 export function buildDefaultPdolData(entries: DolEntry[], options: PdolBuildOptions): Buffer {
-    const { amount, currencyCode, transactionType = 0x00, overrides = new Map<number, Buffer>() } = options;
+    const {
+        amount,
+        currencyCode,
+        transactionType = 0x00,
+        overrides = new Map<number, Buffer>(),
+    } = options;
 
     // Build default values for common PDOL tags
     const defaults = new Map<number, Buffer>([
-        [0x9f02, amountToBcd(amount)],                                    // Amount, Authorized
-        [0x9f03, Buffer.alloc(6)],                                        // Amount, Other
+        [0x9f02, amountToBcd(amount)], // Amount, Authorized
+        [0x9f03, Buffer.alloc(6)], // Amount, Other
         [0x9f1a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Terminal Country Code
         [0x5f2a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Transaction Currency Code
-        [0x9a, getCurrentDateBcd()],                                      // Transaction Date
-        [0x9c, Buffer.from([transactionType])],                           // Transaction Type
-        [0x9f37, generateUnpredictableNumber()],                          // Unpredictable Number
-        [0x9f35, Buffer.from([0x22])],                                    // Terminal Type
-        [0x9f45, Buffer.alloc(2)],                                        // Data Authentication Code
-        [0x9f34, Buffer.from([0x00, 0x00, 0x00])],                         // CVM Results
-        [0x9f66, Buffer.from([0x86, 0x00, 0x00, 0x00])],                   // TTQ (Terminal Transaction Qualifiers)
+        [0x9a, getCurrentDateBcd()], // Transaction Date
+        [0x9c, Buffer.from([transactionType])], // Transaction Type
+        [0x9f37, generateUnpredictableNumber()], // Unpredictable Number
+        [0x9f35, Buffer.from([0x22])], // Terminal Type
+        [0x9f45, Buffer.alloc(2)], // Data Authentication Code
+        [0x9f34, Buffer.from([0x00, 0x00, 0x00])], // CVM Results
+        [0x9f66, Buffer.from([0x86, 0x00, 0x00, 0x00])], // TTQ (Terminal Transaction Qualifiers)
     ]);
 
     // Merge user overrides
@@ -444,14 +454,14 @@ export function buildDefaultCdolData(options: CdolBuildOptions): Buffer {
 
     // Standard CDOL1 fields in typical order
     const defaults = new Map<number, Buffer>([
-        [0x9f02, amountToBcd(amount)],                                    // Amount, Authorized (6 bytes)
-        [0x9f03, Buffer.alloc(6)],                                        // Amount, Other (6 bytes)
+        [0x9f02, amountToBcd(amount)], // Amount, Authorized (6 bytes)
+        [0x9f03, Buffer.alloc(6)], // Amount, Other (6 bytes)
         [0x9f1a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Terminal Country Code (2 bytes)
-        [0x95, tvr],                                                      // TVR (5 bytes)
+        [0x95, tvr], // TVR (5 bytes)
         [0x5f2a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Transaction Currency Code (2 bytes)
-        [0x9a, getCurrentDateBcd()],                                      // Transaction Date (3 bytes)
-        [0x9c, Buffer.from([transactionType])],                           // Transaction Type (1 byte)
-        [0x9f37, generateUnpredictableNumber()],                          // Unpredictable Number (4 bytes)
+        [0x9a, getCurrentDateBcd()], // Transaction Date (3 bytes)
+        [0x9c, Buffer.from([transactionType])], // Transaction Type (1 byte)
+        [0x9f37, generateUnpredictableNumber()], // Unpredictable Number (4 bytes)
     ]);
 
     // Merge user overrides
@@ -461,14 +471,14 @@ export function buildDefaultCdolData(options: CdolBuildOptions): Buffer {
 
     // Build in standard CDOL1 order
     return Buffer.concat([
-        defaults.get(0x9f02) ?? Buffer.alloc(6),  // Amount
-        defaults.get(0x9f03) ?? Buffer.alloc(6),  // Other Amount
-        defaults.get(0x9f1a) ?? Buffer.alloc(2),  // Country Code
-        defaults.get(0x95) ?? Buffer.alloc(5),    // TVR
-        defaults.get(0x5f2a) ?? Buffer.alloc(2),  // Currency
-        defaults.get(0x9a) ?? Buffer.alloc(3),    // Date
-        defaults.get(0x9c) ?? Buffer.alloc(1),    // Type
-        defaults.get(0x9f37) ?? Buffer.alloc(4),  // Unpredictable Number
+        defaults.get(0x9f02) ?? Buffer.alloc(6), // Amount
+        defaults.get(0x9f03) ?? Buffer.alloc(6), // Other Amount
+        defaults.get(0x9f1a) ?? Buffer.alloc(2), // Country Code
+        defaults.get(0x95) ?? Buffer.alloc(5), // TVR
+        defaults.get(0x5f2a) ?? Buffer.alloc(2), // Currency
+        defaults.get(0x9a) ?? Buffer.alloc(3), // Date
+        defaults.get(0x9c) ?? Buffer.alloc(1), // Type
+        defaults.get(0x9f37) ?? Buffer.alloc(4), // Unpredictable Number
     ]);
 }
 
@@ -524,15 +534,24 @@ export function parseCvmList(buffer: Buffer): CvmList {
  */
 function cvmCodeToMethod(code: number): CvmMethod {
     switch (code) {
-        case 0x00: return 'fail';
-        case 0x01: return 'plaintext_pin_icc';
-        case 0x02: return 'enciphered_pin_online';
-        case 0x03: return 'plaintext_pin_icc_signature';
-        case 0x04: return 'enciphered_pin_icc';
-        case 0x05: return 'enciphered_pin_icc_signature';
-        case 0x1e: return 'signature';
-        case 0x1f: return 'no_cvm';
-        default: return 'unknown';
+        case 0x00:
+            return 'fail';
+        case 0x01:
+            return 'plaintext_pin_icc';
+        case 0x02:
+            return 'enciphered_pin_online';
+        case 0x03:
+            return 'plaintext_pin_icc_signature';
+        case 0x04:
+            return 'enciphered_pin_icc';
+        case 0x05:
+            return 'enciphered_pin_icc_signature';
+        case 0x1e:
+            return 'signature';
+        case 0x1f:
+            return 'no_cvm';
+        default:
+            return 'unknown';
     }
 }
 
@@ -541,17 +560,28 @@ function cvmCodeToMethod(code: number): CvmMethod {
  */
 function conditionByteToCondition(code: number): CvmCondition {
     switch (code) {
-        case 0x00: return 'always';
-        case 0x01: return 'unattended_cash';
-        case 0x02: return 'not_unattended_cash_manual_pin';
-        case 0x03: return 'terminal_supports_cvm';
-        case 0x04: return 'manual_cash';
-        case 0x05: return 'purchase_with_cashback';
-        case 0x06: return 'amount_under_x';
-        case 0x07: return 'amount_over_x';
-        case 0x08: return 'amount_under_y';
-        case 0x09: return 'amount_over_y';
-        default: return 'unknown';
+        case 0x00:
+            return 'always';
+        case 0x01:
+            return 'unattended_cash';
+        case 0x02:
+            return 'not_unattended_cash_manual_pin';
+        case 0x03:
+            return 'terminal_supports_cvm';
+        case 0x04:
+            return 'manual_cash';
+        case 0x05:
+            return 'purchase_with_cashback';
+        case 0x06:
+            return 'amount_under_x';
+        case 0x07:
+            return 'amount_over_x';
+        case 0x08:
+            return 'amount_under_y';
+        case 0x09:
+            return 'amount_over_y';
+        default:
+            return 'unknown';
     }
 }
 
@@ -575,7 +605,11 @@ export function evaluateCvm(cvmList: CvmList, context: CvmContext): CvmRule | un
 /**
  * Evaluate a CVM condition against the transaction context
  */
-function evaluateCondition(condition: CvmCondition, cvmList: CvmList, context: CvmContext): boolean {
+function evaluateCondition(
+    condition: CvmCondition,
+    cvmList: CvmList,
+    context: CvmContext
+): boolean {
     switch (condition) {
         case 'always':
             return true;
@@ -584,9 +618,11 @@ function evaluateCondition(condition: CvmCondition, cvmList: CvmList, context: C
             return context.unattendedCash === true;
 
         case 'not_unattended_cash_manual_pin':
-            return context.unattendedCash !== true &&
-                   context.manualCash !== true &&
-                   context.purchaseWithCashback !== true;
+            return (
+                context.unattendedCash !== true &&
+                context.manualCash !== true &&
+                context.purchaseWithCashback !== true
+            );
 
         case 'terminal_supports_cvm':
             return context.terminalSupportsCvm === true;
@@ -620,9 +656,12 @@ function evaluateCondition(condition: CvmCondition, cvmList: CvmList, context: C
  */
 function cryptogramTypeToByte(type: 'ARQC' | 'TC' | 'AAC'): number {
     switch (type) {
-        case 'AAC': return 0x00;
-        case 'TC': return 0x40;
-        case 'ARQC': return 0x80;
+        case 'AAC':
+            return 0x00;
+        case 'TC':
+            return 0x40;
+        case 'ARQC':
+            return 0x80;
     }
 }
 
@@ -632,10 +671,14 @@ function cryptogramTypeToByte(type: 'ARQC' | 'TC' | 'AAC'): number {
 function byteToCryptogramType(cid: number): 'ARQC' | 'TC' | 'AAC' | undefined {
     const type = cid & 0xc0;
     switch (type) {
-        case 0x00: return 'AAC';
-        case 0x40: return 'TC';
-        case 0x80: return 'ARQC';
-        default: return undefined;
+        case 0x00:
+            return 'AAC';
+        case 0x40:
+            return 'TC';
+        case 0x80:
+            return 'ARQC';
+        default:
+            return undefined;
     }
 }
 
@@ -654,6 +697,16 @@ function amountToBcd(amount: number): Buffer {
 }
 
 /**
+ * Convert a 2-character decimal string to a BCD byte.
+ * Each character becomes a nibble: "25" -> 0x25 (high nibble 2, low nibble 5)
+ */
+export function stringToBcd(str: string): number {
+    const high = parseInt(str[0] ?? '0', 10);
+    const low = parseInt(str[1] ?? '0', 10);
+    return (high << 4) | low;
+}
+
+/**
  * Get current date as BCD YYMMDD
  */
 function getCurrentDateBcd(): Buffer {
@@ -661,11 +714,7 @@ function getCurrentDateBcd(): Buffer {
     const year = (now.getFullYear() % 100).toString().padStart(2, '0');
     const month = (now.getMonth() + 1).toString().padStart(2, '0');
     const day = now.getDate().toString().padStart(2, '0');
-    return Buffer.from([
-        parseInt(year, 16),
-        parseInt(month, 16),
-        parseInt(day, 16),
-    ]);
+    return Buffer.from([stringToBcd(year), stringToBcd(month), stringToBcd(day)]);
 }
 
 /**
@@ -916,7 +965,9 @@ export class EmvApplication {
      */
     async getProcessingOptions(pdolData?: Buffer | readonly number[]): Promise<CardResponse> {
         const data = pdolData
-            ? (Buffer.isBuffer(pdolData) ? pdolData : Buffer.from(pdolData))
+            ? Buffer.isBuffer(pdolData)
+                ? pdolData
+                : Buffer.from(pdolData)
             : Buffer.alloc(0);
 
         const apdu = buildGpoApdu(data);
@@ -1000,17 +1051,27 @@ export class EmvApplication {
 
         // Build default tag values for PDOL
         const defaultPdolValues = new Map<number, Buffer>([
-            [0x9f02, amountToBcd(amount)],                                    // Amount, Authorized
-            [0x9f03, Buffer.alloc(6)],                                        // Amount, Other
+            [0x9f02, amountToBcd(amount)], // Amount, Authorized
+            [0x9f03, Buffer.alloc(6)], // Amount, Other
             [0x9f1a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Terminal Country Code
             [0x5f2a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Transaction Currency Code
-            [0x9a, getCurrentDateBcd()],                                      // Transaction Date
-            [0x9c, Buffer.from([transactionType])],                           // Transaction Type
-            [0x9f37, Buffer.from([Math.random() * 256, Math.random() * 256, Math.random() * 256, Math.random() * 256].map(Math.floor))], // Unpredictable Number
-            [0x9f35, Buffer.from([0x22])],                                    // Terminal Type
-            [0x9f45, Buffer.alloc(2)],                                        // Data Authentication Code
-            [0x9f34, Buffer.from([0x00, 0x00, 0x00])],                         // CVM Results
-            [0x9f66, Buffer.from([0x86, 0x00, 0x00, 0x00])],                   // TTQ (Terminal Transaction Qualifiers)
+            [0x9a, getCurrentDateBcd()], // Transaction Date
+            [0x9c, Buffer.from([transactionType])], // Transaction Type
+            [
+                0x9f37,
+                Buffer.from(
+                    [
+                        Math.random() * 256,
+                        Math.random() * 256,
+                        Math.random() * 256,
+                        Math.random() * 256,
+                    ].map(Math.floor)
+                ),
+            ], // Unpredictable Number
+            [0x9f35, Buffer.from([0x22])], // Terminal Type
+            [0x9f45, Buffer.alloc(2)], // Data Authentication Code
+            [0x9f34, Buffer.from([0x00, 0x00, 0x00])], // CVM Results
+            [0x9f66, Buffer.from([0x86, 0x00, 0x00, 0x00])], // TTQ (Terminal Transaction Qualifiers)
         ]);
 
         // Merge with user-provided values
@@ -1063,16 +1124,26 @@ export class EmvApplication {
         // Step 3: Build CDOL data and Generate AC
         // Use a minimal CDOL if we don't have the actual CDOL from the card
         const defaultCdolValues = new Map<number, Buffer>([
-            [0x9f02, amountToBcd(amount)],                                    // Amount, Authorized
-            [0x9f03, Buffer.alloc(6)],                                        // Amount, Other
+            [0x9f02, amountToBcd(amount)], // Amount, Authorized
+            [0x9f03, Buffer.alloc(6)], // Amount, Other
             [0x9f1a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Terminal Country Code
-            [0x95, Buffer.alloc(5)],                                          // TVR
+            [0x95, Buffer.alloc(5)], // TVR
             [0x5f2a, Buffer.from([(currencyCode >> 8) & 0xff, currencyCode & 0xff])], // Transaction Currency Code
-            [0x9a, getCurrentDateBcd()],                                      // Transaction Date
-            [0x9c, Buffer.from([transactionType])],                           // Transaction Type
-            [0x9f37, Buffer.from([Math.random() * 256, Math.random() * 256, Math.random() * 256, Math.random() * 256].map(Math.floor))], // Unpredictable Number
-            [0x82, aip ?? Buffer.alloc(2)],                                   // AIP
-            [0x9f36, Buffer.alloc(2)],                                        // ATC (placeholder)
+            [0x9a, getCurrentDateBcd()], // Transaction Date
+            [0x9c, Buffer.from([transactionType])], // Transaction Type
+            [
+                0x9f37,
+                Buffer.from(
+                    [
+                        Math.random() * 256,
+                        Math.random() * 256,
+                        Math.random() * 256,
+                        Math.random() * 256,
+                    ].map(Math.floor)
+                ),
+            ], // Unpredictable Number
+            [0x82, aip ?? Buffer.alloc(2)], // AIP
+            [0x9f36, Buffer.alloc(2)], // ATC (placeholder)
         ]);
 
         // Merge with user-provided values
@@ -1082,14 +1153,14 @@ export class EmvApplication {
 
         // Build a minimal CDOL data buffer (common fields)
         const cdolData = Buffer.concat([
-            defaultCdolValues.get(0x9f02) ?? Buffer.alloc(6),  // Amount
-            defaultCdolValues.get(0x9f03) ?? Buffer.alloc(6),  // Other Amount
-            defaultCdolValues.get(0x9f1a) ?? Buffer.alloc(2),  // Country Code
-            defaultCdolValues.get(0x95) ?? Buffer.alloc(5),    // TVR
-            defaultCdolValues.get(0x5f2a) ?? Buffer.alloc(2),  // Currency
-            defaultCdolValues.get(0x9a) ?? Buffer.alloc(3),    // Date
-            defaultCdolValues.get(0x9c) ?? Buffer.alloc(1),    // Type
-            defaultCdolValues.get(0x9f37) ?? Buffer.alloc(4),  // Unpredictable Number
+            defaultCdolValues.get(0x9f02) ?? Buffer.alloc(6), // Amount
+            defaultCdolValues.get(0x9f03) ?? Buffer.alloc(6), // Other Amount
+            defaultCdolValues.get(0x9f1a) ?? Buffer.alloc(2), // Country Code
+            defaultCdolValues.get(0x95) ?? Buffer.alloc(5), // TVR
+            defaultCdolValues.get(0x5f2a) ?? Buffer.alloc(2), // Currency
+            defaultCdolValues.get(0x9a) ?? Buffer.alloc(3), // Date
+            defaultCdolValues.get(0x9c) ?? Buffer.alloc(1), // Type
+            defaultCdolValues.get(0x9f37) ?? Buffer.alloc(4), // Unpredictable Number
         ]);
 
         const cryptogramByte = cryptogramTypeToByte(cryptogramType);
@@ -1110,7 +1181,8 @@ export class EmvApplication {
         const cryptogram = findTagInBuffer(acResponse.buffer, 0x9f26);
         const atcBuffer = findTagInBuffer(acResponse.buffer, 0x9f36);
 
-        const returnedCryptogramType = cid && cid[0] !== undefined ? byteToCryptogramType(cid[0]) : undefined;
+        const returnedCryptogramType =
+            cid && cid[0] !== undefined ? byteToCryptogramType(cid[0]) : undefined;
         const atc = atcBuffer && atcBuffer.length >= 2 ? atcBuffer.readUInt16BE(0) : undefined;
 
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,37 @@
-export { EmvApplication, createEmvApplication, default, parseAfl, parsePdol, buildPdolData, buildDefaultPdolData, buildDefaultCdolData, parseCvmList, evaluateCvm } from './emv-application.js';
-export type { AflEntry, DolEntry, TransactionOptions, TransactionResult, RecordData, PdolBuildOptions, CdolBuildOptions, CvmMethod, CvmCondition, CvmRule, CvmList, CvmContext } from './emv-application.js';
-export { EMV_TAGS, format, findTag, findTagInBuffer, getTagName, formatGpoResponse } from './emv-tags.js';
+export {
+    EmvApplication,
+    createEmvApplication,
+    default,
+    parseAfl,
+    parsePdol,
+    buildPdolData,
+    buildDefaultPdolData,
+    buildDefaultCdolData,
+    parseCvmList,
+    evaluateCvm,
+    stringToBcd,
+} from './emv-application.js';
+export type {
+    AflEntry,
+    DolEntry,
+    TransactionOptions,
+    TransactionResult,
+    RecordData,
+    PdolBuildOptions,
+    CdolBuildOptions,
+    CvmMethod,
+    CvmCondition,
+    CvmRule,
+    CvmList,
+    CvmContext,
+} from './emv-application.js';
+export {
+    EMV_TAGS,
+    format,
+    findTag,
+    findTagInBuffer,
+    getTagName,
+    formatGpoResponse,
+} from './emv-tags.js';
 export type { CardResponse, SmartCard, Reader } from './types.js';
 export type { Tlv } from '@tomkp/ber-tlv';


### PR DESCRIPTION
## TL;DR
Fixes BCD date encoding and exports a reusable `stringToBcd()` helper.

## What's changing
- `getCurrentDateBcd()` now correctly encodes dates using proper BCD logic
- New exported `stringToBcd()` function for converting 2-char decimal strings to BCD bytes

## Why?
The original code used `parseInt(year, 16)` which treats the string as hex. While this accidentally works for most valid date digits (0-9), it's semantically wrong and could cause subtle issues. The fix uses explicit nibble encoding: `(high << 4) | low`.

Closes #117